### PR TITLE
add metadata headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 0.1.5
+
+- Fixed an issue when passing `doNotRecord: false` as option, support for metadata fields
+
+# 0.1.4
+
+- Allow Node 18 (engines.node set to >= 18)
+
+# 0.1.3
+
+- First publicly used version 🎉🎉🎉

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtail/node",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "./dist/LangtailNode.js",
   "packageManager": "pnpm@8.15.6",
@@ -29,12 +29,12 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^20.12.5",
+    "@types/node": "^20.12.7",
     "dotenv": "^16.4.5",
     "nock": "14.0.0-beta.5",
     "prettier": "^3.2.5",
     "tsup": "^8.0.2",
-    "typescript": "^5.4.4",
+    "typescript": "^5.4.5",
     "vitest": "^1.4.0",
     "zod": "^3.22.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ dependencies:
 
 devDependencies:
   '@types/node':
-    specifier: ^20.12.5
-    version: 20.12.5
+    specifier: ^20.12.7
+    version: 20.12.7
   dotenv:
     specifier: ^16.4.5
     version: 16.4.5
@@ -24,13 +24,13 @@ devDependencies:
     version: 3.2.5
   tsup:
     specifier: ^8.0.2
-    version: 8.0.2(typescript@5.4.4)
+    version: 8.0.2(typescript@5.4.5)
   typescript:
-    specifier: ^5.4.4
-    version: 5.4.4
+    specifier: ^5.4.5
+    version: 5.4.5
   vitest:
     specifier: ^1.4.0
-    version: 1.4.0(@types/node@20.12.5)
+    version: 1.4.0(@types/node@20.12.7)
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -436,7 +436,7 @@ packages:
   /@types/node-fetch@2.6.11:
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       form-data: 4.0.0
     dev: false
 
@@ -446,8 +446,8 @@ packages:
       undici-types: 5.26.5
     dev: false
 
-  /@types/node@20.12.5:
-    resolution: {integrity: sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==}
+  /@types/node@20.12.7:
+    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
     dependencies:
       undici-types: 5.26.5
 
@@ -1520,7 +1520,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsup@8.0.2(typescript@5.4.4):
+  /tsup@8.0.2(typescript@5.4.5):
     resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
     engines: {node: '>=18'}
     hasBin: true
@@ -1553,7 +1553,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tree-kill: 1.2.2
-      typescript: 5.4.4
+      typescript: 5.4.5
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -1564,8 +1564,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript@5.4.4:
-    resolution: {integrity: sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==}
+  /typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1577,7 +1577,7 @@ packages:
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  /vite-node@1.4.0(@types/node@20.12.5):
+  /vite-node@1.4.0(@types/node@20.12.7):
     resolution: {integrity: sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1586,7 +1586,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.1.6(@types/node@20.12.5)
+      vite: 5.1.6(@types/node@20.12.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -1598,7 +1598,7 @@ packages:
       - terser
     dev: true
 
-  /vite@5.1.6(@types/node@20.12.5):
+  /vite@5.1.6(@types/node@20.12.7):
     resolution: {integrity: sha512-yYIAZs9nVfRJ/AiOLCA91zzhjsHUgMjB+EigzFb6W2XTLO8JixBCKCjvhKZaye+NKYHCrkv3Oh50dH9EdLU2RA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1626,7 +1626,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       esbuild: 0.19.12
       postcss: 8.4.36
       rollup: 4.13.0
@@ -1634,7 +1634,7 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.4.0(@types/node@20.12.5):
+  /vitest@1.4.0(@types/node@20.12.7):
     resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -1659,7 +1659,7 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.12.5
+      '@types/node': 20.12.7
       '@vitest/expect': 1.4.0
       '@vitest/runner': 1.4.0
       '@vitest/snapshot': 1.4.0
@@ -1677,8 +1677,8 @@ packages:
       strip-literal: 2.0.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.1.6(@types/node@20.12.5)
-      vite-node: 1.4.0(@types/node@20.12.5)
+      vite: 5.1.6(@types/node@20.12.7)
+      vite-node: 1.4.0(@types/node@20.12.7)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/src/LangtailNode.spec.ts
+++ b/src/LangtailNode.spec.ts
@@ -15,7 +15,7 @@ describe("LangtailNode", () => {
       ],
       stream: true,
       model: "gpt-3.5-turbo",
-
+      doNotRecord: false,
       metadata: {
         "custom-field": 1,
       },
@@ -35,6 +35,26 @@ describe("LangtailNode", () => {
       .post("/chat/completions")
       .reply(200, function (uri, req) {
         expect(this.req.headers["x-langtail-do-not-record"][0]).toBe("true")
+        expect(this.req.headers["x-langtail-metadata-custom-field"][0]).toBe(
+          "1",
+        )
+
+        // check that body has no metadata or doNotRecord
+        expect(req).toMatchInlineSnapshot(`
+          {
+            "messages": [
+              {
+                "content": "You are a helpful assistant.",
+                "role": "system",
+              },
+              {
+                "content": "What is the weather like?",
+                "role": "user",
+              },
+            ],
+            "model": "gpt-3.5-turbo",
+          }
+        `)
       })
     await lt.chat.completions.create({
       messages: [
@@ -44,6 +64,9 @@ describe("LangtailNode", () => {
 
       model: "gpt-3.5-turbo",
       doNotRecord: true,
+      metadata: {
+        "custom-field": 1,
+      },
     })
 
     expect(nock.pendingMocks()).toEqual([])

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -1,6 +1,6 @@
 import "dotenv/config"
 import { describe, expect, it } from "vitest"
-import nock from "nock"
+
 import { LangtailPrompts } from "./LangtailPrompts"
 import { openAIStreamingResponseSchema } from "./dataSchema"
 
@@ -104,6 +104,7 @@ describe(
         project: "ci-tests-project",
         fetch: async (url, init) => {
           expect(init?.headers?.["x-langtail-do-not-record"]).toBe("true")
+          expect(init?.headers?.["x-langtail-metadata-custom-field"]).toBe(1)
 
           return {
             ok: true,
@@ -128,6 +129,9 @@ describe(
           about: "napoleon",
         },
         doNotRecord: true,
+        metadata: {
+          "custom-field": 1,
+        },
       })
 
       expect(res.httpResponse.status).toBe(200)

--- a/src/LangtailPrompts.ts
+++ b/src/LangtailPrompts.ts
@@ -8,10 +8,7 @@ import { Stream } from "openai/streaming"
 import { ILangtailExtraProps } from "./LangtailNode"
 import { Fetch } from "openai/core"
 
-export type Environment =
-  | "preview"
-  | "staging"
-  | "production"
+export type Environment = "preview" | "staging" | "production"
 
 interface LangtailPromptVariables {} // TODO use this when generating schema for deployed prompts
 
@@ -93,14 +90,23 @@ export class LangtailPrompts {
     prompt,
     environment,
     doNotRecord,
+    metadata,
     ...rest
   }: IRequestParams | IRequestParamsStream) {
+    const metadataHeaders = metadata
+      ? Object.entries(metadata).reduce((acc, [key, value]) => {
+          acc[`x-langtail-metadata-${key}`] = value
+          return acc
+        }, {})
+      : {}
+
     const fetchInit = {
       method: "POST",
       headers: {
         "X-API-Key": this.apiKey,
         "content-type": "application/json",
         "x-langtail-do-not-record": doNotRecord ? "true" : "false",
+        ...metadataHeaders,
       },
       body: JSON.stringify({ stream: false, ...rest }),
     }


### PR DESCRIPTION
- fixes issue found by @rhefner1 today when `doNotRecord: false` is used
- adds metadata headers for both LangtailPrompts and LangtailNode