### PR TITLE
add _record function forLangtailPrompts and implicit completion flow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
       - name: run tests
         env:
           LANGTAIL_API_KEY: ${{secrets.LANGTAIL_API_KEY}}
+          OPENAI_API_KEY: ${{secrets.OPENAI_API_KEY}}
         run: pnpm test
 
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+- change return type of `build` to `Promise<IPromptObject>`
+- add `lt.completions.create` method to directly call openAI SDK with the output of `build` method
+
 # 0.3.1
 
 - fix next.js compatibility

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ const playgroundState = await lt.get({
 render your template and builds the final open AI compatible payload:
 
 ```ts
-const openAiBody = lt.build(playgroundState, {
+const preparedPrompt = lt.build(playgroundState, {
   stream: true,
   variables: {
     topic: "iron man",
@@ -170,10 +170,11 @@ const openAiBody = lt.build(playgroundState, {
 })
 ```
 
-openAiBody now contains this object:
+preparedPrompt now contains this object:
 
 ```js
 {
+            "stream": true,
             "frequency_penalty": 0,
             "max_tokens": 800,
             "messages": [
@@ -194,9 +195,29 @@ Notice that your langtail template was replaced with a variable passed in. You c
 ```ts
 import OpenAI from "openai"
 
-const openai = new OpenAI()
+const openAI = new OpenAI()
 
-const joke = await openai.chat.completions.create(openAiBody)
+const jokeCompletion = await openAI.chat.completions.create(
+  preparedPrompt.toOpenAI(),
+)
 ```
 
 This way you are still using langtail prompts without exposing potentially sensitive data in your variables.
+In case you wish to use the proxyless feature and keep having your logs visible in langtail, use the `preparedPrompt` in the `lt.completions.create` call like this:
+
+### Proxyless with Langtail logs
+
+```ts
+const lt = new LangtailPrompts({
+  apiKey: "<LANGTAIL_API_KEY>",
+  openAIKey: "<OPENAI_API>", // required for the completions.create to work, you can also define it as env variable OPENAI_API_KEY
+})
+
+const preparedPrompt = lt.build(playgroundState, {
+  variables: {
+    topic: "iron man",
+  },
+})
+
+const jokeCompletion = await lt.completions.create(preparedPrompt) // results in an openAI ChatCompletion and you can see the request in langtail logs. Variables pass
+```

--- a/cspell.json
+++ b/cspell.json
@@ -5,7 +5,9 @@
   "dictionaries": [],
   "words": [
     "Aragorn",
+    "datetime",
     "Langtail",
+    "logprobs",
     "undici"
   ],
   "ignoreWords": [],

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,7 @@
     "datetime",
     "Langtail",
     "logprobs",
+    "proxyless",
     "undici"
   ],
   "ignoreWords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.3.1",
+  "version": "0.3.2-beta-0",
   "description": "",
   "main": "./dist/LangtailNode.js",
   "packageManager": "pnpm@8.15.6",
@@ -54,6 +54,11 @@
       "require": "./dist/template.js",
       "import": "./dist/template.mjs",
       "types": "./dist/template.d.ts"
+    },
+    "./dist/dataSchema": {
+      "require": "./dist/dataSchema.js",
+      "import": "./dist/dataSchema.mjs",
+      "types": "./dist/dataSchema.d.ts"
     }
   },
   "files": [
@@ -64,7 +69,7 @@
     "@langtail/handlebars-evalless": "^0.1.1",
     "date-fns": "^3.6.0",
     "handlebars": "^4.7.8",
-    "openai": "^4.43.0",
+    "openai": "^4.45.0",
     "query-string": "^9.0.0",
     "zod": "^3.23.8"
   },
@@ -79,7 +84,8 @@
     "entryPoints": [
       "src/LangtailNode.ts",
       "src/template.ts",
-      "src/getOpenAIBody.ts"
+      "src/getOpenAIBody.ts",
+      "src/dataSchema.ts"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "natural language processing",
     "gpt-3",
     "gpt-4",
+    "openrouter",
     "anthropic"
   ],
   "authors": [
@@ -65,11 +66,10 @@
     "dist"
   ],
   "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.0.0",
     "@langtail/handlebars-evalless": "^0.1.1",
     "date-fns": "^3.6.0",
     "handlebars": "^4.7.8",
-    "openai": "^4.45.0",
+    "openai": "^4.46.1",
     "query-string": "^9.0.0",
     "zod": "^3.23.8"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.3.2-beta-0",
+  "version": "0.4.0-beta-0",
   "description": "",
   "main": "./dist/LangtailNode.js",
   "packageManager": "pnpm@8.15.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@asteasolutions/zod-to-openapi':
-    specifier: ^7.0.0
-    version: 7.0.0(zod@3.23.8)
   '@langtail/handlebars-evalless':
     specifier: ^0.1.1
     version: 0.1.1
@@ -18,8 +15,8 @@ dependencies:
     specifier: ^4.7.8
     version: 4.7.8
   openai:
-    specifier: ^4.45.0
-    version: 4.45.0
+    specifier: ^4.46.1
+    version: 4.46.1
   query-string:
     specifier: ^9.0.0
     version: 9.0.0
@@ -51,15 +48,6 @@ devDependencies:
     version: 1.6.0(@types/node@20.12.11)
 
 packages:
-
-  /@asteasolutions/zod-to-openapi@7.0.0(zod@3.23.8):
-    resolution: {integrity: sha512-rJRKHD2m6nUb/9ZheeN8nqOURX24WTzY8Sex1ZKT0Kpx+xfpRcD0fTD6vEeXNHGaDGxzu65Jj/jb2x6nLTjcMw==}
-    peerDependencies:
-      zod: ^3.20.2
-    dependencies:
-      openapi3-ts: 4.3.1
-      zod: 3.23.8
-    dev: false
 
   /@esbuild/aix-ppc64@0.19.12:
     resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
@@ -1243,8 +1231,8 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
-  /openai@4.45.0:
-    resolution: {integrity: sha512-uszUQrl9eQPCA9a7Zml+Eizb3mG0JDd8zUl528OM6Ccn039dqbOmUivL5s8zUM6iJMRMvNGRMXS9yuuR1Bv2sw==}
+  /openai@4.46.1:
+    resolution: {integrity: sha512-YILOwSwyg6h4FqDCehzZ/vu0hI6eQWXv7BQ/nNNyRHbprerZmkiRYBzq2h4iiJKUOrIw66APE46ZW/iP8y8Fiw==}
     hasBin: true
     dependencies:
       '@types/node': 18.19.24
@@ -1257,12 +1245,6 @@ packages:
       web-streams-polyfill: 3.3.3
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /openapi3-ts@4.3.1:
-    resolution: {integrity: sha512-ha/kTOLhMQL7MvS9Abu/cpCXx5qwHQ++88YkUzn1CGfmM8JvCOG/4ZE6tRsexgXRFaoJrcwLyf81H2Y/CXALtA==}
-    dependencies:
-      yaml: 2.4.1
     dev: false
 
   /p-limit@5.0.0:
@@ -1869,6 +1851,7 @@ packages:
     resolution: {integrity: sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==}
     engines: {node: '>= 14'}
     hasBin: true
+    dev: true
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ dependencies:
     specifier: ^4.7.8
     version: 4.7.8
   openai:
-    specifier: ^4.43.0
-    version: 4.43.0
+    specifier: ^4.45.0
+    version: 4.45.0
   query-string:
     specifier: ^9.0.0
     version: 9.0.0
@@ -1243,8 +1243,8 @@ packages:
       mimic-fn: 4.0.0
     dev: true
 
-  /openai@4.43.0:
-    resolution: {integrity: sha512-4SMUB/XiqnO5IrEcdzEGGTcHoeXq7D/k82v36zoqSitrMUjenZXGH5JysIH7aF7Wr+gjvq0dT2mV6wLVKA7Seg==}
+  /openai@4.45.0:
+    resolution: {integrity: sha512-uszUQrl9eQPCA9a7Zml+Eizb3mG0JDd8zUl528OM6Ccn039dqbOmUivL5s8zUM6iJMRMvNGRMXS9yuuR1Bv2sw==}
     hasBin: true
     dependencies:
       '@types/node': 18.19.24

--- a/src/LangtailNode.spec.ts
+++ b/src/LangtailNode.spec.ts
@@ -30,7 +30,7 @@ describe("LangtailNode", () => {
     expect(partCount > 1).toBe(true)
   })
 
-  it("should not record", async (t) => {
+  it("should not record this completion in the logs", async (t) => {
     nock(baseURL) // nock works by intercepting requests at the network level, if open AI switches to undici we will need to intercept differently
       .post("/chat/completions")
       .reply(200, function (uri, req) {

--- a/src/LangtailNode.spec.ts
+++ b/src/LangtailNode.spec.ts
@@ -2,7 +2,7 @@ import { LangtailNode, baseURL } from "./LangtailNode"
 import "dotenv/config"
 import { describe, expect, it } from "vitest"
 import nock from "nock"
-import { openAIStreamingResponseSchema } from "./dataSchema"
+import { ChatCompletionChunkSchema } from "./dataSchema"
 
 const lt = new LangtailNode()
 
@@ -24,7 +24,7 @@ describe("LangtailNode", () => {
     for await (const part of proxyCompletion) {
       partCount++
 
-      openAIStreamingResponseSchema.parse(part)
+      ChatCompletionChunkSchema.parse(part)
     }
 
     expect(partCount > 1).toBe(true)

--- a/src/LangtailNode.ts
+++ b/src/LangtailNode.ts
@@ -22,6 +22,10 @@ export interface ILangtailExtraProps extends OpenAiBodyType {
   metadata?: Record<string, any>
 }
 
+export type ChatCompletionsCreateParams =
+  | (ChatCompletionCreateParamsStreaming & ILangtailExtraProps)
+  | (ChatCompletionCreateParamsNonStreaming & ILangtailExtraProps)
+
 export class LangtailNode {
   prompts: LangtailPrompts
   chat: {

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -153,17 +153,17 @@ describe(
 
     describe("build", () => {
       const ltLocal = new LangtailPrompts({
-        // baseURL: "https://api-staging.langtail.com",
+       // baseURL: "https://api-staging.langtail.com",// uncomment this line to test against local prompt api
         apiKey: process.env.LANGTAIL_API_KEY!,
       })
 
       it("should return the openAI body user can use with openai client", async () => {
-        const playgroundState = await ltLocal.get({
+        const prompt = await ltLocal.get({
           prompt: "optional-var-test",
           environment: "preview",
           version: "c8hrwdiz",
         })
-        expect(playgroundState).toMatchInlineSnapshot(`
+        expect(prompt).toMatchInlineSnapshot(`
           {
             "chatInput": {
               "optionalExtra": "",
@@ -195,12 +195,11 @@ describe(
           }
         `)
 
-        const promptObj = ltLocal.build(playgroundState, {
+        const promptObj = ltLocal.build(prompt, {
           stream: true,
           variables: {
             optionalExtra: "This is an optional extra",
           },
-          
         })
 
         expect(promptObj.toOpenAI()).toMatchInlineSnapshot(`
@@ -222,6 +221,32 @@ describe(
             "top_p": 1,
           }
         `)
+      })
+    })
+
+    describe("completion proxyless use case", () => {
+      it("should return completion for ai clock prompt", async () => {
+        const ltLocal = new LangtailPrompts({
+          baseURL: "https://api-staging.langtail.com",
+          apiKey: "lt-eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJsYW5ndGFpbC1hcGkiLCJzdWIiOiJjbG11cTVndW8wMDA0bDkwOHZvbjFvMjhmIiwianRpIjoiY2x1MThrczg0MDAwMTl1Y2JsOGFueHl5ZCIsInJhdGVMaW1pdCI6bnVsbCwiaWF0IjoxNzExMDI1Nzg5fQ.pXT-4CsIenb1VchGaSMxfn7ZBeQHdASWGSs-r7Ryk9uVrfgk7ju5bFDRHWY9N6ua42SrwTx75m5u6Un4wxONUQ",
+
+        })
+    
+        const promptPlaygroundState = await ltLocal.get({
+          prompt: "ai-clock",
+          environment: "preview",
+          version: "yjxvsqwx",
+        })
+        const preparedPrompt = ltLocal.build(promptPlaygroundState, {
+          variables: {
+            time: "13:11",
+          
+          }
+        })
+
+        const completion = await ltLocal.completions.create(preparedPrompt)
+
+        expect(completion.choices[0].message.content.length > 10).toBeTruthy()
       })
     })
   },

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -17,12 +17,23 @@ describe(
       it("should return the correct path for project prompt", () => {
         const path = lt._createPromptPath({
           prompt: "prompt",
-          environment: "staging",
+          environment: "preview",
           version: "6vy19bmp",
         })
 
         expect(path).toBe(
-          "https://api.langtail.com/project-prompt/prompt/staging?v=6vy19bmp",
+          "https://api.langtail.com/project-prompt/prompt/preview?v=6vy19bmp",
+        )
+      })
+
+      it("staging with no version parameter", () => {
+        const path = lt._createPromptPath({
+          prompt: "prompt",
+          environment: "staging",
+        })
+
+        expect(path).toBe(
+          "https://api.langtail.com/project-prompt/prompt/staging",
         )
       })
 
@@ -35,23 +46,23 @@ describe(
 
         const path = ltProject._createPromptPath({
           prompt: "prompt",
-          environment: "staging",
+          environment: "preview",
           version: "6vy19bmp",
         })
 
         expect(path).toBe(
-          "https://api.langtail.com/some-workspace/ci-tests-project/prompt/staging?v=6vy19bmp",
+          "https://api.langtail.com/some-workspace/ci-tests-project/prompt/preview?v=6vy19bmp",
         )
 
         const pathForPromptConfig = ltProject._createPromptPath({
           prompt: "prompt",
-          environment: "staging",
+          environment: "preview",
           version: "6vy19bmp",
           configGet: true,
         })
 
         expect(pathForPromptConfig).toBe(
-          "https://api.langtail.com/some-workspace/ci-tests-project/prompt/staging?open-ai-completion-config-payload=true&v=6vy19bmp",
+          "https://api.langtail.com/some-workspace/ci-tests-project/prompt/preview?open-ai-completion-config-payload=true&v=6vy19bmp",
         )
       })
     })

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -195,7 +195,7 @@ describe(
           }
         `)
 
-        const openAiBody = ltLocal.build(playgroundState, {
+        const promptObj = ltLocal.build(playgroundState, {
           stream: true,
           variables: {
             optionalExtra: "This is an optional extra",
@@ -203,7 +203,7 @@ describe(
           
         })
 
-        expect(openAiBody).toMatchInlineSnapshot(`
+        expect(promptObj.toOpenAI()).toMatchInlineSnapshot(`
           {
             "frequency_penalty": 0,
             "max_tokens": 800,

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -2,7 +2,7 @@ import "dotenv/config"
 import { describe, expect, it } from "vitest"
 
 import { LangtailPrompts } from "./LangtailPrompts"
-import { openAIStreamingResponseSchema } from "./dataSchema"
+import { ChatCompletionChunkSchema } from "./dataSchema"
 
 const lt = new LangtailPrompts({
   apiKey: process.env.LANGTAIL_API_KEY!,
@@ -98,11 +98,12 @@ describe(
           },
           stream: true,
         })
+
         let partCount = 0
         for await (const part of proxyCompletion) {
           partCount++
 
-          openAIStreamingResponseSchema.parse(part)
+          ChatCompletionChunkSchema.parse(part)
         }
 
         expect(partCount > 1).toBe(true)
@@ -153,7 +154,7 @@ describe(
 
     describe("build", () => {
       const ltLocal = new LangtailPrompts({
-       // baseURL: "https://api-staging.langtail.com",// uncomment this line to test against local prompt api
+        // baseURL: "https://api-staging.langtail.com",// uncomment this line to test against local prompt api
         apiKey: process.env.LANGTAIL_API_KEY!,
       })
 
@@ -228,9 +229,10 @@ describe(
       it("should return completion for ai clock prompt", async () => {
         const ltLocal = new LangtailPrompts({
           baseURL: "https://api-staging.langtail.com",
-          apiKey: "lt-eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJsYW5ndGFpbC1hcGkiLCJzdWIiOiJjbG11cTVndW8wMDA0bDkwOHZvbjFvMjhmIiwianRpIjoiY2x1MThrczg0MDAwMTl1Y2JsOGFueHl5ZCIsInJhdGVMaW1pdCI6bnVsbCwiaWF0IjoxNzExMDI1Nzg5fQ.pXT-4CsIenb1VchGaSMxfn7ZBeQHdASWGSs-r7Ryk9uVrfgk7ju5bFDRHWY9N6ua42SrwTx75m5u6Un4wxONUQ",
+          apiKey:
+            "lt-eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJsYW5ndGFpbC1hcGkiLCJzdWIiOiJjbG11cTVndW8wMDA0bDkwOHZvbjFvMjhmIiwianRpIjoiY2x1MThrczg0MDAwMTl1Y2JsOGFueHl5ZCIsInJhdGVMaW1pdCI6bnVsbCwiaWF0IjoxNzExMDI1Nzg5fQ.pXT-4CsIenb1VchGaSMxfn7ZBeQHdASWGSs-r7Ryk9uVrfgk7ju5bFDRHWY9N6ua42SrwTx75m5u6Un4wxONUQ",
         })
-    
+
         const promptPlaygroundState = await ltLocal.get({
           prompt: "ai-clock",
           environment: "preview",
@@ -239,8 +241,7 @@ describe(
         const preparedPrompt = ltLocal.build(promptPlaygroundState, {
           variables: {
             time: "13:11",
-          
-          }
+          },
         })
 
         const completion = await ltLocal.completions.create(preparedPrompt)

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -229,7 +229,6 @@ describe(
         const ltLocal = new LangtailPrompts({
           baseURL: "https://api-staging.langtail.com",
           apiKey: "lt-eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJsYW5ndGFpbC1hcGkiLCJzdWIiOiJjbG11cTVndW8wMDA0bDkwOHZvbjFvMjhmIiwianRpIjoiY2x1MThrczg0MDAwMTl1Y2JsOGFueHl5ZCIsInJhdGVMaW1pdCI6bnVsbCwiaWF0IjoxNzExMDI1Nzg5fQ.pXT-4CsIenb1VchGaSMxfn7ZBeQHdASWGSs-r7Ryk9uVrfgk7ju5bFDRHWY9N6ua42SrwTx75m5u6Un4wxONUQ",
-
         })
     
         const promptPlaygroundState = await ltLocal.get({

--- a/src/LangtailPrompts.ts
+++ b/src/LangtailPrompts.ts
@@ -103,6 +103,7 @@ export class LangtailPrompts {
       v: version,
       "open-ai-completion-config-payload": configGet,
     })
+    const queryParamsString = queryParams ? `?${queryParams}` : ""
 
     if (this.options.workspace && this.options.project) {
       const url = `${this.baseUrl}/${this.options.workspace}/${this.options.project}/${prompt}/${environment}?${queryParams}`
@@ -112,13 +113,13 @@ export class LangtailPrompts {
     }
 
     if (this.options.project) {
-      return `${this.options.project}/${prompt}/${environment}?${queryParams}`
+      return `${this.options.project}/${prompt}/${environment}${queryParamsString}`
     }
 
     const urlPath = `project-prompt/${prompt}/${environment}`
     return urlPath.startsWith("/")
-      ? this.baseUrl + urlPath + `?${queryParams}`
-      : `${this.baseUrl}/${urlPath}?${queryParams}`
+      ? this.baseUrl + urlPath + `${queryParamsString}`
+      : `${this.baseUrl}/${urlPath}${queryParamsString}`
   }
 
   invoke(

--- a/src/LangtailPrompts.ts
+++ b/src/LangtailPrompts.ts
@@ -278,7 +278,7 @@ export class LangtailPrompts {
         ).asResponse()
 
         if (openAIBody.stream) {
-        
+          
         }
   
         const finishedAt = new Date()

--- a/src/LangtailPrompts.ts
+++ b/src/LangtailPrompts.ts
@@ -1,10 +1,11 @@
-import {
-  ChatCompletion,
-} from "openai/resources/chat/completions"
+import { ChatCompletion } from "openai/resources/chat/completions"
 import { ChatCompletionChunk } from "openai/resources/chat/completions"
 
 import { Stream } from "openai/streaming"
-import { ChatCompletionsCreateParams, ILangtailExtraProps, LangtailNode } from "./LangtailNode"
+import {
+  ChatCompletionsCreateParams,
+  ILangtailExtraProps,
+} from "./LangtailNode"
 import { Fetch } from "openai/core"
 import { userAgent } from "./userAgent"
 import queryString from "query-string"
@@ -52,7 +53,6 @@ type PromptIdProps = {
   environment?: LangtailEnvironment
   version?: string
 }
-
 
 interface IRequestParams extends IPromptIdProps {
   variables?: Record<string, any>
@@ -202,9 +202,11 @@ export class LangtailPrompts {
      **/
     environment?: LangtailEnvironment
     version?: string
-    }): Promise<PlaygroundState & {
-    _promptIdProps: PromptIdProps
-  }> {
+  }): Promise<
+    PlaygroundState & {
+      _promptIdProps: PromptIdProps
+    }
+  > {
     const promptPath = this._createPromptPath({
       prompt,
       environment: environment ?? "production",
@@ -226,11 +228,6 @@ export class LangtailPrompts {
     }
 
     const payload = await res.json()
-    // payload._promptIdProps = {
-    //   prompt,
-    //   environment,
-    //   version,
-    // }
 
     Object.defineProperty(payload, "_promptIdProps", {
       value: {
@@ -242,7 +239,7 @@ export class LangtailPrompts {
       enumerable: false,
       configurable: false,
     })
-    
+
     return payload
   }
 
@@ -263,46 +260,37 @@ export class LangtailPrompts {
 
   completions = {
     create: async (prompt: IPromptObject) => {
-
-
       const openAI = new OpenAI({
-        apiKey: this.openAIKey
+        apiKey: this.openAIKey,
       })
 
       const openAIBody = prompt.toOpenAI()
 
-        const startedAt = new Date()      
+      const startedAt = new Date()
 
-        const completionResponse = await openAI.chat.completions.create(
-          openAIBody,
-        ).asResponse()
+      const completionResponse = await openAI.chat.completions
+        .create(openAIBody)
+        .asResponse()
 
-        if (openAIBody.stream) {
-          
-        }
-  
-        const finishedAt = new Date()
-  
-        const data = completionResponse.status > 299 ? null : await completionResponse.json()
-        void this._record(
-          prompt._promptIdProps,
-          prompt.toOpenAI(),
-          {
-            data: data,
-            startedAt: startedAt.toISOString(),
-            finishedAt: finishedAt.toISOString(),
-            status: completionResponse.status,
-            error: completionResponse.status > 299 ? await completionResponse.json() : null,
-          }
-        )
+      if (openAIBody.stream) {
+      }
 
-        return data
+      const finishedAt = new Date()
 
+      const data =
+        completionResponse.status > 299 ? null : await completionResponse.json()
+      void this._record(prompt._promptIdProps, prompt.toOpenAI(), {
+        data: data,
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        status: completionResponse.status,
+        error:
+          completionResponse.status > 299
+            ? await completionResponse.json()
+            : null,
+      })
 
-
-
-     
-
+      return data
     },
   }
 

--- a/src/dataSchema.ts
+++ b/src/dataSchema.ts
@@ -4,10 +4,19 @@ import { openAIBodySchema } from "./getOpenAIBody"
 const choiceStreamedSchema = z.object({
   index: z.number(),
   delta: z.any(), // Adjust based on the actual shape of delta
-  logprobs: z.null(),
+  logprobs: z
+    .array(
+      z.object({
+        token: z.string(),
+        bytes: z.array(z.number()),
+        logprob: z.number(),
+        top_logprobs: z.record(z.number()),
+      }),
+    )
+    .nullish(),
   finish_reason: z.string().nullable(),
 })
-export const openAIStreamingResponseSchema = z.object({
+export const ChatCompletionChunkSchema = z.object({
   id: z.string(),
   object: z.literal("chat.completion.chunk"),
   created: z.number(),
@@ -46,7 +55,7 @@ const ChatCompletionSchema = z.object({
 export const OpenAIResponseSchema = z.object({
   status: z.number(),
   error: ErrorObjectSchema.nullable().optional(),
-  data: ChatCompletionSchema,
+  data: z.union([ChatCompletionSchema, z.array(ChatCompletionChunkSchema)]),
   finishedAt: z.string().datetime(),
   startedAt: z.string().datetime(),
 })

--- a/src/dataSchema.ts
+++ b/src/dataSchema.ts
@@ -1,6 +1,6 @@
 import z from "zod"
+import { openAIBodySchema } from "./getOpenAIBody"
 
-// Define the schema for the data
 const choiceStreamedSchema = z.object({
   index: z.number(),
   delta: z.any(), // Adjust based on the actual shape of delta
@@ -15,3 +15,48 @@ export const openAIStreamingResponseSchema = z.object({
   system_fingerprint: z.string().nullish(), // TODO change back to non nullable when openAI fixes the issue where system_fingerprint is returned as null
   choices: z.array(choiceStreamedSchema),
 })
+
+const ErrorObjectSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+})
+
+const ChatCompletionSchema = z.object({
+  id: z.string(),
+  object: z.string(),
+  created: z.number(),
+  choices: z.array(
+    z.object({
+      index: z.number(),
+      message: z.object({
+        role: z.string(),
+        content: z.string(),
+      }),
+      finish_reason: z.string().nullable(),
+    }),
+  ),
+  model: z.string(),
+  usage: z.object({
+    prompt_tokens: z.number(),
+    completion_tokens: z.number(),
+    total_tokens: z.number(),
+  }),
+})
+
+export const OpenAIResponseSchema = z.object({
+  status: z.number(),
+  error: ErrorObjectSchema.nullable().optional(),
+  data: ChatCompletionSchema,
+  finishedAt: z.string().datetime(),
+  startedAt: z.string().datetime(),
+})
+
+export type OpenAIResponseType = z.infer<typeof OpenAIResponseSchema>
+
+// validation and types of the log data
+export const LogDataSchema = z.object({
+  input: openAIBodySchema,
+  openAIResponse: OpenAIResponseSchema,
+})
+
+export type LogDataType = z.infer<typeof LogDataSchema>

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -1,6 +1,5 @@
 import type OpenAI from "openai"
 import { z } from "zod"
-import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi"
 
 import {
   MessageSchema,
@@ -11,34 +10,22 @@ import {
 import { compileLTTemplate } from "./template"
 import { ChatCompletionsCreateParams } from "./LangtailNode"
 
-extendZodWithOpenApi(z)
-
 export const bodyMetadataSchema = z
   .record(z.string().max(64), z.union([z.string(), z.number()]))
   .optional()
 
 export const langtailBodySchema = z.object({
-  doNotRecord: z.boolean().optional().openapi({
-    description:
-      "If true, potentially sensitive data like the prompt and response will not be recorded in the logs",
-    example: false,
-  }),
+  doNotRecord: z.boolean().optional(),
   metadata: bodyMetadataSchema,
   _langtailTestRunId: z.string().optional(),
   _langtailTestInputId: z.string().optional(),
 })
 
 export const openAIBodySchemaObjectDefinition = {
-  stream: z.boolean().optional().openapi({ example: false }),
-  user: z.string().optional().openapi({
-    description: "A unique identifier representing your end-user",
-    example: "user_123",
-  }),
+  stream: z.boolean().optional(),
+  user: z.string().optional(),
 
-  seed: z.number().optional().openapi({
-    description: "A seed is used  to generate reproducible results",
-    example: 123,
-  }),
+  seed: z.number().optional(),
   max_tokens: z.number().optional(),
   temperature: z.number().optional(),
   top_p: z.number().optional(),
@@ -55,18 +42,7 @@ export const openAIBodySchemaObjectDefinition = {
       type: z.enum(["json_object"]),
     })
     .optional(),
-  messages: z
-    .array(MessageSchema)
-    .optional()
-    .openapi({
-      description: "Additional messages to seed the conversation with",
-      example: [
-        {
-          role: "user",
-          content: "Hello",
-        },
-      ],
-    }),
+  messages: z.array(MessageSchema).optional(),
 }
 export const openAIBodySchema = z.object(openAIBodySchemaObjectDefinition)
 
@@ -171,4 +147,3 @@ export function getOpenAIBody(
   }
   return openAIbody as ChatCompletionsCreateParams
 }
-

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -27,7 +27,7 @@ export const langtailBodySchema = z.object({
   _langtailTestInputId: z.string().optional(),
 })
 
-export const openAiBodySchema = z.object({
+export const openAIBodySchemaObjectDefinition = {
   stream: z.boolean().optional().openapi({ example: false }),
   user: z.string().optional().openapi({
     description: "A unique identifier representing your end-user",
@@ -66,12 +66,13 @@ export const openAiBodySchema = z.object({
         },
       ],
     }),
-})
+}
+export const openAIBodySchema = z.object(openAIBodySchemaObjectDefinition)
 
-export const bothBodySchema = langtailBodySchema.merge(openAiBodySchema)
+export const bothBodySchema = langtailBodySchema.merge(openAIBodySchema)
 
 export type IncomingBodyType = z.infer<typeof bothBodySchema>
-export type OpenAiBodyType = z.infer<typeof openAiBodySchema>
+export type OpenAiBodyType = z.infer<typeof openAIBodySchema>
 
 /**
  * Get the body for the OpenAI API request. Used in the langtail prompt API. // TODO remove this from our prompt-API when this is merged so that we don't have this code duplicated
@@ -135,7 +136,7 @@ export function getOpenAIBody(
     }
   }
 
-  if (completionArgs.stop || parsedBody.stop) { 
+  if (completionArgs.stop || parsedBody.stop) {
     openAIbody.stop = parsedBody.stop ?? completionArgs.stop
   }
 

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -9,6 +9,7 @@ import {
   ToolSchema,
 } from "./schemas"
 import { compileLTTemplate } from "./template"
+import { ChatCompletionsCreateParams } from "./LangtailNode"
 
 extendZodWithOpenApi(z)
 
@@ -80,7 +81,7 @@ export type OpenAiBodyType = z.infer<typeof openAIBodySchema>
 export function getOpenAIBody(
   completionConfig: PlaygroundState,
   parsedBody: IncomingBodyType,
-) {
+): ChatCompletionsCreateParams {
   const completionArgs = completionConfig.state.args
 
   const template = parsedBody.template ?? completionConfig.state.template
@@ -168,7 +169,6 @@ export function getOpenAIBody(
       content: "format: JSON",
     })
   }
-  return openAIbody
+  return openAIbody as ChatCompletionsCreateParams
 }
 
-export type ChatCompletionCreateParams = OpenAI.Chat.ChatCompletionCreateParams


### PR DESCRIPTION
https://linear.app/langtail/issue/LAN-341/sdk-logs-for-proxyless-invocation

  - [x] _record method added
  - [x]  implicit flow with the new prompt object
  - [x]  docs
  
  this needs https://github.com/langtail/langtail/pull/394 to be merged to work as it uses that endpoint