### PR TITLE
don't return stop parameter in getOpenAIBody if it's empty array & schemas entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# misc
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.5.4
+
+- Fix: don't send `stop` parameter if it's empty (this causes validation error in OpenAI in some cases)
+
 # 0.5.3
 
 - Fix CommonJS support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 0.5.4
 
 - Fix: don't send `stop` parameter if it's empty (this causes validation error in OpenAI in some cases)
+- Add schemas to entrypoints
 
 # 0.5.3
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.5.3",
+  "version": "0.5.4-beta.0",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.5.4-beta.0",
+  "version": "0.5.4-beta.1",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",
@@ -72,6 +72,11 @@
       "import": "./openai.mjs",
       "types": "./openai.d.ts"
     },
+    "./schemas": {
+      "require": "./schemas.js",
+      "import": "./schemas.mjs",
+      "types": "./schemas.d.ts"
+    },
     "./stream": {
       "require": "./stream/index.js",
       "import": "./stream/index.mjs",
@@ -122,6 +127,7 @@
       "src/openai.ts",
       "src/vercel-ai/index.ts",
       "src/bin/entry.ts",
+      "src/schemas.ts",
       "src/stream/index.ts",
       "src/react/useChatStream.ts"
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.5.4-beta.1",
+  "version": "0.5.4",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",

--- a/src/LangtailPrompts.spec.ts
+++ b/src/LangtailPrompts.spec.ts
@@ -231,7 +231,6 @@ describe.skipIf(!liveTesting)(
             ],
             "model": "gpt-3.5-turbo",
             "presence_penalty": 0,
-            "stop": [],
             "temperature": 0.5,
             "top_p": 1,
           }

--- a/src/getOpenAIBody.test.ts
+++ b/src/getOpenAIBody.test.ts
@@ -17,7 +17,6 @@ describe("getOpenAIBody", () => {
       top_p: 1,
       presence_penalty: 0,
       frequency_penalty: 0,
-      stop: [],
     }
 
     const openAIbody = getOpenAIBody(
@@ -88,7 +87,6 @@ describe("getOpenAIBody", () => {
         ],
         "model": "gpt-3.5-turbo",
         "presence_penalty": 0,
-        "stop": [],
         "temperature": 0.8,
         "top_p": 1,
       }
@@ -113,7 +111,6 @@ describe("getOpenAIBody", () => {
         ],
         "model": "gpt-3.5-turbo",
         "presence_penalty": 0,
-        "stop": [],
         "temperature": 0.8,
         "top_p": 1,
       }
@@ -244,7 +241,6 @@ describe("getOpenAIBody", () => {
         "model": "gpt-3.5-turbo",
         "presence_penalty": 0,
         "seed": 123,
-        "stop": [],
         "temperature": 0.8,
         "top_p": 1,
       }

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -67,8 +67,8 @@ export function getOpenAIBody(
     }
   }
 
-  if (completionArgs.stop || parsedBody.stop) {
-    openAIbody.stop = parsedBody.stop ?? completionArgs.stop
+  if (parsedBody.stop) {
+    openAIbody.stop = parsedBody.stop
   }
 
   const toolChoice = parsedBody.tool_choice ?? completionArgs.tool_choice


### PR DESCRIPTION
sending `"stop": []` causes 400 validation error in OpenAI in some cases - we observed it when there is any image in messages