### PR TITLE
fix: handle passed single chat message to the fetcher param

### DIFF
--- a/src/react/useChatStream.test.ts
+++ b/src/react/useChatStream.test.ts
@@ -1,7 +1,7 @@
 
 import { describe, expect, it, vi } from "vitest"
 import { renderHook, act } from "@testing-library/react"
-import { useChatStream } from "./useChatStream"
+import { type ChatMessage, useChatStream } from "./useChatStream"
 import { EventEmitter } from "stream"
 import { JSDOM } from 'jsdom'
 
@@ -64,6 +64,25 @@ describe("useAIStream", () => {
   })
 
   describe("public API", () => {
+    it("type test: passing one message to send()", async () => {
+      const mockedStream = new ReadableStream()
+
+      const createReadableStream = vi.fn((parameter) => {
+        expect(parameter).toEqual({ role: 'user', content: 'hello' })
+        return Promise.resolve(mockedStream)
+      })
+
+      const { result } = renderHook(() => useChatStream<ChatMessage | ChatMessage[] | string>({ fetcher: createReadableStream }))
+
+      act(() => {
+        result.current.send({ role: 'user', content: 'hello' })
+      })
+
+      await vi.waitFor(() => {
+        expect(createReadableStream).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it("should pass paramters of send() to the createReadableStream()", async () => {
       const mockedStream = new ReadableStream()
 

--- a/src/react/useChatStream.ts
+++ b/src/react/useChatStream.ts
@@ -12,7 +12,7 @@ const defaultReturn = {
   abort: () => { },
 }
 
-type ChatMessage =
+export type ChatMessage =
   | {
     role: "user" | "assistant" | "system"
     content: string | null
@@ -119,22 +119,26 @@ export function combineAIMessageChunkWithCompleteMessages(
 }
 
 function parameterToMessage(
-  parameter: ChatMessage[] | string,
+  parameter: ChatMessage | ChatMessage[] | string,
 ): ChatMessage[] {
   if (Array.isArray(parameter)) {
     return parameter
   }
 
-  return [
-    {
-      role: "user",
-      content: parameter,
-    },
-  ]
+  if (typeof parameter === "string") {
+    return [
+      {
+        role: "user",
+        content: parameter,
+      },
+    ]
+  }
+
+  return [parameter]
 }
 
 export function useChatStream<
-  P extends ChatMessage[] | string,
+  P extends ChatMessage[] | ChatMessage | string,
   O extends Record<string, any> = Record<string, any>,
 >(
   options: {


### PR DESCRIPTION
## Problem
The readme example for calling the `useChatStream` hook doesn't work:
```ts
send({ role: 'user' , content: "Can you hear me?"})
```

This causes error when the data is passed like this:
```ts
{
        "role": "user",
        "content": {
            "role": "user",
            "content": "Can you hear me?"
        }
}
```

The `content` should be an array.

This PR fixes this bug.
