### PR TITLE
fix: ensure that loading is false directly when abort is clicked

### DIFF
--- a/src/react/useChatStream.ts
+++ b/src/react/useChatStream.ts
@@ -218,6 +218,7 @@ export function useChatStream<
       setMessagesState(messages)
     },
     abort: () => {
+      setIsLoadingState(false)
       runnerRef.current.abort()
       abortControllerRef.current?.abort()
     },


### PR DESCRIPTION
fixes:
- ensure that abort propages immediatly