### PR TITLE
ensure that open ai message shape is recognized better

### DIFF
--- a/src/react/useChatStream.ts
+++ b/src/react/useChatStream.ts
@@ -27,7 +27,7 @@ export function mapAIMessagesToChatCompletions(
   messages: (ChatCompletion | ChatMessage)[],
 ): ChatMessage[] {
   return messages.flatMap((message) => {
-    if ("id" in message) {
+    if ("id" in message && "choices" in message) {
       return message.choices.map((choice) => {
         return choice.message
       })


### PR DESCRIPTION
- it happens that when you send and usual shape of message it causes error - eg. including `id`