### PR TITLE
re-export Stream as helper function from SDK

### DIFF
--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -1,5 +1,6 @@
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import { AssistantStream } from 'openai/lib/AssistantStream';
+import { Stream } from "openai/streaming"
 
 
 export const chatStreamToRunner = (stream: ReadableStream<any>): ChatCompletionStream => {
@@ -9,7 +10,12 @@ export const assistantStreamToRunner = (stream: ReadableStream<any>): AssistantS
   return AssistantStream.fromReadableStream(stream);
 }
 
+export const readableStreamFromSSEResponse = (reponse: Response, controller?: AbortController): ReadableStream<any> => {
+  return Stream.fromSSEResponse(reponse, controller || new AbortController()).toReadableStream();
+}
+
 export type {
   ChatCompletionStream,
-  AssistantStream
+  AssistantStream,
+  Stream
 }


### PR DESCRIPTION
Exports useful function that handles responses from LLM.

Typical streamed response , when there request is made through OpenAI SDK / Langtail SDK looks like:
```
{ "id": "sfcvxdd34sdfsdf", choices: [] } 
```

But when the response is raw stream it adds prefixes:
```
data: { "id": "sfcvxdd34sdfsdf", choices: [] } 
data: [DONE]
```

These are stripped by the SDKs. But it is possible that custom backend may return version with streaming prefixes.
