### PR TITLE
remove needless assistant:true param from assistant call

### DIFF
--- a/src/LangtailAssistants.spec.ts
+++ b/src/LangtailAssistants.spec.ts
@@ -43,7 +43,6 @@ describe("LangtailAssistants", () => {
 
       expect(promptsMock.invoke).toHaveBeenCalledWith(
         expect.objectContaining({
-          assistant: true,
           prompt: assistant,
         })
       );
@@ -91,7 +90,6 @@ describe("LangtailAssistants", () => {
       });
 
       expect(promptsMock.invoke).toHaveBeenCalledWith({
-        assistant: true,
         prompt: assistant,
         messages,
       });
@@ -109,34 +107,17 @@ describe("LangtailAssistants", () => {
     });
   })
 
-  it("should pass assistant: true by default to langtailPrompts.invoke call", async () => {
+  it("should not pass assistant: true to langtailPrompts.invoke call", async () => {
     const { lt, promptsMock } = createLt();
     const assistant = "test-assistant";
 
     await lt.invoke({ assistant });
 
     expect(promptsMock.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
+      expect.not.objectContaining({
         assistant: true,
-        prompt: "test-assistant",
       })
     );
+    expect(promptsMock.invoke.mock.calls[0][0]).not.toHaveProperty('assistant');
   });
-
-  it("should pass threadId to langtailPrompts.invoke call when provided", async () => {
-    const { lt, promptsMock } = createLt();
-    const assistant = "test-assistant";
-    const threadId = "test-thread-id";
-
-    await lt.invoke({ assistant, threadId });
-
-    expect(promptsMock.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
-        assistant: true,
-        prompt: assistant,
-        threadId: threadId,
-      })
-    );
-  });
-
 })

--- a/src/LangtailAssistants.ts
+++ b/src/LangtailAssistants.ts
@@ -12,14 +12,13 @@ export class LangtailAssistants {
     this.langtailPrompts = langtailPrompts
   }
 
-  invoke<P extends PromptSlug, E extends Environment<P> = undefined, V extends Version<P, E> = undefined, S extends boolean = false>(options: Omit<IRequestParamsStream<P, E, V, S>, "prompt" | "assistant"> & {
+  invoke<P extends PromptSlug, E extends Environment<P> = undefined, V extends Version<P, E> = undefined, S extends boolean = false>(options: Omit<IRequestParamsStream<P, E, V, S>, "prompt"> & {
     assistant: P
   }): Promise<S extends true ? StreamResponseType : OpenAIResponseWithHttp> {
     const { assistant, ...rest } = options
     return this.langtailPrompts.invoke<P, E, V, S>({
       ...rest,
       prompt: assistant,
-      assistant: true,
     })
   }
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,7 +8,6 @@ import type {
 export interface ILangtailExtraProps {
   doNotRecord?: boolean
   threadId?: string
-  assistant?: boolean
   metadata?: Record<string, any>
 }
 


### PR DESCRIPTION
- `assistant: true` won't be needed in the API