### PR TITLE
keep the tool_calls in final message callback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langtail",
-  "version": "0.13.6-beta.0",
+  "version": "0.13.6-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langtail",
-      "version": "0.13.6-beta.0",
+      "version": "0.13.6-beta.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^0.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "langtail",
-  "version": "0.13.4",
+  "version": "0.13.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "langtail",
-      "version": "0.13.4",
+      "version": "0.13.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.13.6-beta.0",
+  "version": "0.13.6-beta.1",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.13.5",
+  "version": "0.13.6-beta.0",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",

--- a/src/react/useChatStream.ts
+++ b/src/react/useChatStream.ts
@@ -146,7 +146,7 @@ export function combineAIMessageChunkWithCompleteMessages(
             ...choice,
             ...{
               ...chunkChoice,
-              finish_reason: 'length' as const,
+              finish_reason: chunkChoice.finish_reason ?? 'length' as const,
             },
             message: {
               ...choice.message,
@@ -162,11 +162,15 @@ export function combineAIMessageChunkWithCompleteMessages(
   })
 }
 
-function normalizeMessage(message: ChatCompletionMessage) {
+function normalizeMessage(message: ChatCompletionMessage, currentMessage?: ChatCompletionChunk) {
+  const toolCalls = (message.tool_calls && message.tool_calls.length === 0 && currentMessage?.choices?.some(choice => (("delta" in choice) && "tool_calls" in choice.delta) && choice.delta?.tool_calls)
+    ? currentMessage?.choices?.flatMap(choice => (("delta" in choice) && "tool_calls" in choice.delta) && Array.isArray(choice.delta?.tool_calls) ? choice.delta?.tool_calls : [])
+    : message.tool_calls ?? []) as ChatCompletionMessageToolCall[]
   return {
     ...message,
     // NOTE: ensure that message isn't null or undefined
     content: message.content ?? "",
+    ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
   }
 }
 
@@ -302,13 +306,19 @@ export function useChatStream<
           }
 
           const onFinalChatCompletion = (finalMessage: ChatCompletion) => {
+            // NOTE: for some reason, tool_calls are empty in finalMessage, that's why we keep them through storing the finalized message
+            const finalizedMessage = messagesRef.current.find((currentMessage) => {
+              return "id" in currentMessage && currentMessage.id === finalMessage.id
+            })
+
             messagesRef.current = messagesRef.current
               .filter(
                 (currentMessage) =>
                   !("id" in currentMessage) ||
                   currentMessage.id !== finalMessage.id,
               )
-              .concat(finalMessage.choices.flatMap((choice) => normalizeMessage(choice.message)))
+              .concat(finalMessage.choices.flatMap((choice) => normalizeMessage(choice.message, finalizedMessage as unknown as (ChatCompletionChunk | undefined))))
+
 
             const userChatMessages = mapAIMessagesToChatCompletions(
               messagesRef.current,


### PR DESCRIPTION
This is pretty weird, for some reason, the `finalMessage` simply contained just an empty array of `tools_calls`. It was supposed (as the callback is named) to contain the complete final message.