### PR TITLE
fix(vercel-ai): fall back to raw args when no JSON prefix is parseable

### DIFF
--- a/src/vercel-ai/langtail-language-model.ts
+++ b/src/vercel-ai/langtail-language-model.ts
@@ -876,12 +876,12 @@ export class LangtailChatLanguageModel<
 
           flush(controller) {
             // Recover any tool calls whose accumulated arguments never became
-            // parseable JSON during streaming. Some models emit the closing
-            // `}` together with trailing characters in the same delta (e.g.
-            // `"}, "extra": false} `), so the per-delta isParsableJson check
-            // above never sees a moment where the buffer is exactly valid
-            // JSON. Without this, the tool call is silently dropped while
-            // finishReason is still `tool-calls`.
+            // parseable JSON during streaming. Some models emit malformed
+            // JSON (closing `}` bundled with trailing junk like `"}, junk`,
+            // or unescaped `"` inside string values) so the per-delta
+            // isParsableJson check never sees a moment where the buffer is
+            // valid JSON. Without recovery the tool call is silently dropped
+            // while finishReason is still `tool-calls`.
             //
             // Gate on finishReason === "tool-calls" so we never synthesize a
             // tool invocation the model didn't actually commit to: if the
@@ -895,16 +895,22 @@ export class LangtailChatLanguageModel<
               for (const toolCall of Object.values(toolCalls)) {
                 if (toolCall == null || toolCall.hasFinished) continue
                 if (toolCall.function?.name == null) continue
-                const recovered = findLongestParsableJsonPrefix(
-                  toolCall.function.arguments,
-                )
-                if (recovered == null) continue
+                const raw = toolCall.function.arguments
+                if (typeof raw !== "string" || raw.length === 0) continue
+                // Prefer the longest valid JSON prefix when one exists
+                // (handles models that emit `{...}, junk` cleanly without
+                // losing semantically valid content). Otherwise pass through
+                // the raw buffered args so downstream tool-call repair (e.g.
+                // AI SDK `experimental_repairToolCall`) can attempt to fix
+                // or re-prompt the model — never silently drop a tool call
+                // the model committed to with finish_reason: "tool_calls".
+                const args = findLongestParsableJsonPrefix(raw) ?? raw
                 controller.enqueue({
                   type: "tool-call",
                   toolCallType: "function",
                   toolCallId: toolCall.id,
                   toolName: toolCall.function.name,
-                  args: recovered,
+                  args,
                 })
                 toolCall.hasFinished = true
               }

--- a/src/vercel-ai/tool-call-recovery.spec.ts
+++ b/src/vercel-ai/tool-call-recovery.spec.ts
@@ -179,7 +179,14 @@ describe("Streaming tool-call recovery", () => {
     scope.done()
   })
 
-  it("does not synthesize a tool-call when args are entirely unparseable", async () => {
+  it("falls back to raw args when no valid JSON prefix exists, so downstream repair can run", async () => {
+    // When args are malformed in a way no parseable prefix can fix
+    // (e.g. unescaped `"` inside a string value, breaking the outer JSON
+    // structure), silently dropping the tool call would surface as
+    // `no_tool_calls` to consumers. Instead, pass the raw buffered args
+    // through so AI SDK's experimental_repairToolCall (or equivalent)
+    // gets a chance to fix or re-prompt the model.
+    const garbage = "garbage no json here"
     const scope = nock(BASE_URL)
       .post(/\/project-prompt\/test-prompt\/production/)
       .reply(
@@ -190,8 +197,7 @@ describe("Streaming tool-call recovery", () => {
             id: "call_2",
             name: "Read",
           }),
-          // never-valid args
-          toolCallChunk({ index: 0, arguments: "garbage no json here" }),
+          toolCallChunk({ index: 0, arguments: garbage }),
           finishChunk("tool_calls"),
         ]),
         { "content-type": "text/event-stream" },
@@ -202,7 +208,60 @@ describe("Streaming tool-call recovery", () => {
     const parts = await collectStreamParts(stream)
 
     const toolCalls = parts.filter((p) => p.type === "tool-call")
-    expect(toolCalls).toHaveLength(0)
+    expect(toolCalls).toHaveLength(1)
+    if (toolCalls[0].type === "tool-call") {
+      expect(toolCalls[0].toolName).toBe("Read")
+      expect(toolCalls[0].args).toBe(garbage)
+    }
+    scope.done()
+  })
+
+  it("falls back to raw args when an unescaped quote breaks JSON inside a string value", async () => {
+    // Real-world Kimi-K2.6 case: model emitted a JSX whitespace
+    // expression `{" "}` inside a TypeScript string value, escaping the
+    // second quote but not the first. The result is JSON like
+    // `{"content": "...{" "}..."}` where the unescaped `"` after `{`
+    // prematurely closes the outer string value, producing a
+    // "Expected ',' or '}' after property value" error mid-buffer. No
+    // prefix is parseable, so findLongestParsableJsonPrefix returns null
+    // and the recovery must fall back to emitting the raw args.
+    const broken =
+      '{"file_path": "page.tsx", "content": "before {" \\"}\\nafter"}'
+    const scope = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/)
+      .reply(
+        200,
+        createSSEResponse([
+          toolCallChunk({
+            index: 0,
+            id: "call_orphan_quote",
+            name: "Write",
+          }),
+          toolCallChunk({ index: 0, arguments: broken }),
+          finishChunk("tool_calls"),
+        ]),
+        { "content-type": "text/event-stream" },
+      )
+
+    const model = createModel()
+    const { stream } = await model.doStream(defaultCallOptions)
+    const parts = await collectStreamParts(stream)
+
+    const toolCalls = parts.filter((p) => p.type === "tool-call")
+    expect(toolCalls).toHaveLength(1)
+    if (toolCalls[0].type === "tool-call") {
+      expect(toolCalls[0].toolName).toBe("Write")
+      expect(toolCalls[0].args).toBe(broken)
+      // Sanity: this shape really is unrecoverable to a clean JSON
+      // prefix — proves the fallback path is what saved us.
+      expect(() => JSON.parse(broken)).toThrow()
+    }
+    // tool-call must precede the finish event so consumers see it as
+    // part of the same step.
+    const toolCallIdx = parts.findIndex((p) => p.type === "tool-call")
+    const finishIdx = parts.findIndex((p) => p.type === "finish")
+    expect(toolCallIdx).toBeGreaterThan(-1)
+    expect(finishIdx).toBeGreaterThan(toolCallIdx)
     scope.done()
   })
 


### PR DESCRIPTION
The flush-time recovery added in 0.16.14 only emits a tool-call when findLongestParsableJsonPrefix returns a non-null prefix. That covers the `{...}, junk` shape (closing `}` bundled with trailing characters) but silently drops other malformations — most notably an unescaped `"` inside a string value, which breaks the outer JSON structure mid-buffer and leaves no parseable prefix at all.

Real-world Kimi-K2.6 case: model wrote a JSX whitespace expression `{" "}` inside a TypeScript string and only escaped the second quote. The buffered args become `{"content": "...{" \"}..."}` — JSON.parse fails with "Expected ',' or '}' after property value", and slicing to that position still leaves an unterminated string. The tool call was silently dropped, surfacing as `no_tool_calls` again.

Pass the raw buffered args through when no clean prefix exists, so downstream tool-call repair (e.g. AI SDK `experimental_repairToolCall`) gets a chance to fix or re-prompt the model. Never silently drop a tool call the model committed to with finish_reason: "tool_calls".

Updates one existing test (entirely-unparseable args now emit a raw tool-call instead of nothing) and adds a regression test for the orphan-quote pattern.