### PR TITLE
Preserve OpenAI Responses reasoning metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,27 @@ tools(ltModel, {
 })
 ```
 
+### OpenAI reasoning across tool steps
+
+OpenAI Responses reasoning items must be sent back together with tool results.
+AI SDK 4 does not copy provider metadata into assistant messages created by its
+automatic `maxSteps` loop. When using OpenAI reasoning models, run tool steps
+explicitly and attach `result.providerMetadata` to the assistant message before
+the next call:
+
+```typescript
+const assistantMessage = result.response.messages.find(
+  message => message.role === 'assistant',
+)
+
+if (assistantMessage) {
+  assistantMessage.providerOptions = result.providerMetadata
+}
+```
+
+Without this metadata, encrypted reasoning cannot be returned to OpenAI on the
+next step.
+
 ## Stream helpers
 
 The AI streams are delivered as JSON objects, which are split into chunks. This can pose a challenge because JSON objects might be distributed across multiple chunks. We have provide you with helper functions to manage these JSON streams more effectively.

--- a/src/getOpenAIBody.test.ts
+++ b/src/getOpenAIBody.test.ts
@@ -44,6 +44,55 @@ describe("getOpenAIBody", () => {
     expect(openAIbody).toEqual(expectedOpenAIbody)
   })
 
+  it("strips Responses provider metadata from Chat Completions messages", () => {
+    const openAIbody = getOpenAIBody(
+      {
+        state: {
+          type: "chat",
+          args: {
+            model: "gpt-4.1-mini",
+            max_tokens: 100,
+            temperature: 0.8,
+            top_p: 1,
+            presence_penalty: 0,
+            frequency_penalty: 0,
+            jsonmode: false,
+            seed: null,
+            stop: [],
+          },
+          template: [],
+        },
+        chatInput: {},
+      },
+      {
+        variables: {},
+        messages: [
+          {
+            role: "assistant",
+            content: "Previous Responses answer",
+            provider_metadata: {
+              openai: {
+                responses: {
+                  output_items: [
+                    {
+                      id: "rs_123",
+                      type: "reasoning",
+                      encrypted_content: "encrypted-reasoning",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    )
+
+    expect(openAIbody.messages).toEqual([
+      { role: "assistant", content: "Previous Responses answer" },
+    ])
+  })
+
   it("should extend variables from playground", () => {
     const completionConfig = {
       state: {

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -6,6 +6,14 @@ import { ChatCompletionsCreateParams, PlaygroundMessage } from "./schemas"
 import { IncomingBodyType, PlaygroundState } from "./schemas"
 import { ChatCompletionMessageParam } from "openai/resources"
 
+function stripProviderMetadata(
+  message: ChatCompletionMessageParam,
+): ChatCompletionMessageParam {
+  const { provider_metadata: _, ...chatCompletionMessage } = message as
+    ChatCompletionMessageParam & { provider_metadata?: unknown }
+  return chatCompletionMessage as ChatCompletionMessageParam
+}
+
 function compileMessages(
   messages: PlaygroundMessage[],
   variables: Record<string, any>,
@@ -55,7 +63,7 @@ export function getOpenAIBody(
     model: parsedBody.model ?? completionArgs.model,
     temperature: parsedBody.temperature ?? completionArgs.temperature,
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
-    messages: inputMessages,
+    messages: inputMessages.map(stripProviderMetadata),
     top_p: parsedBody.top_p ?? completionArgs.top_p,
     ...(parsedBody.parallelToolCalls !== undefined
       ? { parallel_tool_calls: parsedBody.parallelToolCalls }

--- a/src/reasoning-details-schema.ts
+++ b/src/reasoning-details-schema.ts
@@ -36,6 +36,7 @@ export const CommonReasoningDetailSchema = z.object({
     ])
     .nullish(),
   index: z.number().optional(),
+  part_index: z.number().optional(),
 })
 
 export const ReasoningDetailSummarySchema = z

--- a/src/reasoning-details.spec.ts
+++ b/src/reasoning-details.spec.ts
@@ -182,11 +182,13 @@ describe("Message Schema with reasoning_details", () => {
 
     const result = MessageSchema.parse({
       role: "assistant",
-      content: "Answer",
+      content: null,
+      refusal: "I cannot help with that request.",
       provider_metadata: providerMetadata,
     })
 
     expect(result.provider_metadata).toEqual(providerMetadata)
+    expect(result.refusal).toBe("I cannot help with that request.")
   })
 
   it("should validate message with reasoning_details", () => {

--- a/src/reasoning-details.spec.ts
+++ b/src/reasoning-details.spec.ts
@@ -20,6 +20,7 @@ describe("ReasoningDetail Schemas", () => {
         id: "reasoning-1",
         format: ReasoningFormat.AnthropicClaudeV1,
         index: 0,
+        part_index: 1,
       }
 
       const result = ReasoningDetailTextSchema.parse(detail)
@@ -164,6 +165,30 @@ describe("ReasoningDetail Schemas", () => {
 })
 
 describe("Message Schema with reasoning_details", () => {
+  it("should preserve OpenAI Responses output items", () => {
+    const providerMetadata = {
+      openai: {
+        responses: {
+          output_items: [
+            {
+              id: "rs_123",
+              type: "reasoning",
+              encrypted_content: "encrypted-reasoning",
+            },
+          ],
+        },
+      },
+    }
+
+    const result = MessageSchema.parse({
+      role: "assistant",
+      content: "Answer",
+      provider_metadata: providerMetadata,
+    })
+
+    expect(result.provider_metadata).toEqual(providerMetadata)
+  })
+
   it("should validate message with reasoning_details", () => {
     const message = {
       role: "assistant",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -137,6 +137,7 @@ export interface Message {
   role: "assistant" | "user" | "system" | "function" | "tool"
   name?: string
   content: string | ContentArray | null
+  refusal?: string | null
   reasoning?: MessageReasoning[] | null
   reasoning_details?: ReasoningDetail[] | null
   provider_metadata?: MessageProviderMetadata
@@ -263,6 +264,7 @@ export const MessageSchema = z.object({
   ]),
   name: z.string().optional(),
   content: ContentArraySchema.or(z.string().nullable()),
+  refusal: z.string().nullable().optional(),
   function_call: FunctionCallSchema.optional(),
   tool_calls: z.array(ToolCallSchema).optional(),
   tool_choice: ToolChoiceSchema.optional(),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -120,12 +120,26 @@ export interface MessageReasoningRedacted {
 
 export type MessageReasoning = MessageReasoningText | MessageReasoningRedacted
 
+export type ProviderResponseOutputItem = {
+  type: string
+  [key: string]: unknown
+}
+
+export interface MessageProviderMetadata {
+  openai?: {
+    responses?: {
+      output_items: ProviderResponseOutputItem[]
+    }
+  }
+}
+
 export interface Message {
   role: "assistant" | "user" | "system" | "function" | "tool"
   name?: string
   content: string | ContentArray | null
   reasoning?: MessageReasoning[] | null
   reasoning_details?: ReasoningDetail[] | null
+  provider_metadata?: MessageProviderMetadata
   function_call?: {
     name: string
     arguments: string
@@ -223,6 +237,22 @@ export const MessageReasoningSchema = z.union([
   MessageReasoningRedactedSchema,
 ]) satisfies z.ZodType<MessageReasoning>
 
+export const ProviderResponseOutputItemSchema = z
+  .object({ type: z.string() })
+  .passthrough() satisfies z.ZodType<ProviderResponseOutputItem>
+
+export const MessageProviderMetadataSchema = z.object({
+  openai: z
+    .object({
+      responses: z
+        .object({
+          output_items: z.array(ProviderResponseOutputItemSchema),
+        })
+        .optional(),
+    })
+    .optional(),
+}) satisfies z.ZodType<MessageProviderMetadata>
+
 export const MessageSchema = z.object({
   role: z.union([
     z.literal("assistant"),
@@ -241,6 +271,7 @@ export const MessageSchema = z.object({
   cache_ttl: z.string().optional(),
   reasoning: z.array(MessageReasoningSchema).optional(),
   reasoning_details: z.array(ReasoningDetailUnionSchema).nullish(),
+  provider_metadata: MessageProviderMetadataSchema.optional(),
 }) satisfies z.ZodType<Message>
 
 const FunctionSchema = z.object({

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -10,6 +10,44 @@ import {
 import type { MessageProviderMetadata, MessageReasoning } from "../schemas"
 import { ReasoningDetail } from "../reasoning-details-schema"
 
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => areJsonValuesEqual(value, right[index]))
+    )
+  }
+
+  if (
+    left === null ||
+    right === null ||
+    typeof left !== "object" ||
+    typeof right !== "object"
+  ) {
+    return false
+  }
+
+  const leftRecord = left as Record<string, unknown>
+  const rightRecord = right as Record<string, unknown>
+  const leftKeys = Object.keys(leftRecord)
+  const rightKeys = Object.keys(rightRecord)
+
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(rightRecord, key) &&
+        areJsonValuesEqual(leftRecord[key], rightRecord[key]),
+    )
+  )
+}
+
 function getOriginalToolCallArguments({
   providerMetadata,
   toolCallId,
@@ -34,8 +72,12 @@ function getOriginalToolCallArguments({
   }
 
   try {
-    return JSON.stringify(JSON.parse(outputItem.arguments)) ===
-      JSON.stringify(args)
+    const serializedArgs = JSON.stringify(args)
+    return serializedArgs !== undefined &&
+      areJsonValuesEqual(
+        JSON.parse(outputItem.arguments),
+        JSON.parse(serializedArgs),
+      )
       ? outputItem.arguments
       : undefined
   } catch {

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -177,6 +177,7 @@ export function convertToOpenAIChatMessages({
         let reasoningDetails: ReasoningDetail[] | undefined
         let responseProviderMetadata: MessageProviderMetadata | undefined
         let refusal: string | undefined
+        let refusalAsText = false
         const toolCalls: Array<{
           id: string
           type: "function"
@@ -189,6 +190,7 @@ export function convertToOpenAIChatMessages({
               reasoning_details?: ReasoningDetail[]
               provider_metadata?: MessageProviderMetadata
               refusal?: string | null
+              refusal_as_text?: boolean
             }
           | undefined
         if (langtailMetadata?.reasoning_details) {
@@ -199,6 +201,9 @@ export function convertToOpenAIChatMessages({
         }
         if (langtailMetadata?.refusal != null) {
           refusal = langtailMetadata.refusal
+        }
+        if (langtailMetadata?.refusal_as_text === true) {
+          refusalAsText = true
         }
 
         for (const part of content) {
@@ -251,7 +256,8 @@ export function convertToOpenAIChatMessages({
         addMessage(
           {
             role: "assistant",
-            content: text,
+            content:
+              refusalAsText && refusal != null && text === refusal ? "" : text,
             refusal,
             reasoning: reasoning.length > 0 ? reasoning : undefined,
             reasoning_details: reasoningDetails,

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -10,6 +10,39 @@ import {
 import type { MessageProviderMetadata, MessageReasoning } from "../schemas"
 import { ReasoningDetail } from "../reasoning-details-schema"
 
+function getOriginalToolCallArguments({
+  providerMetadata,
+  toolCallId,
+  toolName,
+  args,
+}: {
+  providerMetadata: MessageProviderMetadata | undefined
+  toolCallId: string
+  toolName: string
+  args: unknown
+}): string | undefined {
+  const outputItem = providerMetadata?.openai?.responses?.output_items.find(
+    (item) =>
+      item.type === "function_call" &&
+      item.call_id === toolCallId &&
+      item.name === toolName &&
+      typeof item.arguments === "string",
+  )
+
+  if (!outputItem || typeof outputItem.arguments !== "string") {
+    return undefined
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(outputItem.arguments)) ===
+      JSON.stringify(args)
+      ? outputItem.arguments
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export function convertToOpenAIChatMessages({
   prompt,
 }: {
@@ -101,6 +134,7 @@ export function convertToOpenAIChatMessages({
         let reasoning: MessageReasoning[] = []
         let reasoningDetails: ReasoningDetail[] | undefined
         let responseProviderMetadata: MessageProviderMetadata | undefined
+        let refusal: string | undefined
         const toolCalls: Array<{
           id: string
           type: "function"
@@ -112,6 +146,7 @@ export function convertToOpenAIChatMessages({
           | {
               reasoning_details?: ReasoningDetail[]
               provider_metadata?: MessageProviderMetadata
+              refusal?: string | null
             }
           | undefined
         if (langtailMetadata?.reasoning_details) {
@@ -119,6 +154,9 @@ export function convertToOpenAIChatMessages({
         }
         if (langtailMetadata?.provider_metadata) {
           responseProviderMetadata = langtailMetadata.provider_metadata
+        }
+        if (langtailMetadata?.refusal != null) {
+          refusal = langtailMetadata.refusal
         }
 
         for (const part of content) {
@@ -149,7 +187,13 @@ export function convertToOpenAIChatMessages({
                 type: "function",
                 function: {
                   name: part.toolName,
-                  arguments: JSON.stringify(part.args),
+                  arguments:
+                    getOriginalToolCallArguments({
+                      providerMetadata: responseProviderMetadata,
+                      toolCallId: part.toolCallId,
+                      toolName: part.toolName,
+                      args: part.args,
+                    }) ?? JSON.stringify(part.args),
                 },
               })
               break
@@ -166,6 +210,7 @@ export function convertToOpenAIChatMessages({
           {
             role: "assistant",
             content: text,
+            refusal,
             reasoning: reasoning.length > 0 ? reasoning : undefined,
             reasoning_details: reasoningDetails,
             provider_metadata: responseProviderMetadata,

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -7,7 +7,7 @@ import {
   OpenAIChatPrompt,
   ChatCompletionContentPart,
 } from "./openai-chat-prompt"
-import { MessageReasoning } from "../schemas"
+import type { MessageProviderMetadata, MessageReasoning } from "../schemas"
 import { ReasoningDetail } from "../reasoning-details-schema"
 
 export function convertToOpenAIChatMessages({
@@ -100,6 +100,7 @@ export function convertToOpenAIChatMessages({
         let text = ""
         let reasoning: MessageReasoning[] = []
         let reasoningDetails: ReasoningDetail[] | undefined
+        let responseProviderMetadata: MessageProviderMetadata | undefined
         const toolCalls: Array<{
           id: string
           type: "function"
@@ -108,10 +109,16 @@ export function convertToOpenAIChatMessages({
 
         // Check if providerMetadata contains preserved reasoning_details
         const langtailMetadata = providerMetadata?.langtail as
-          | { reasoning_details?: ReasoningDetail[] }
+          | {
+              reasoning_details?: ReasoningDetail[]
+              provider_metadata?: MessageProviderMetadata
+            }
           | undefined
         if (langtailMetadata?.reasoning_details) {
           reasoningDetails = langtailMetadata.reasoning_details
+        }
+        if (langtailMetadata?.provider_metadata) {
+          responseProviderMetadata = langtailMetadata.provider_metadata
         }
 
         for (const part of content) {
@@ -161,6 +168,7 @@ export function convertToOpenAIChatMessages({
             content: text,
             reasoning: reasoning.length > 0 ? reasoning : undefined,
             reasoning_details: reasoningDetails,
+            provider_metadata: responseProviderMetadata,
             tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           },
           cacheEnabled,

--- a/src/vercel-ai/langtail-language-model.ts
+++ b/src/vercel-ai/langtail-language-model.ts
@@ -453,7 +453,8 @@ export class LangtailChatLanguageModel<
     if (
       (choice.message.reasoning_details &&
         choice.message.reasoning_details.length > 0) ||
-      choice.message.provider_metadata
+      choice.message.provider_metadata ||
+      choice.message.refusal != null
     ) {
       if (!providerMetadata) {
         providerMetadata = {}
@@ -472,6 +473,9 @@ export class LangtailChatLanguageModel<
               provider_metadata: choice.message
                 .provider_metadata as unknown as JSONValue,
             }
+          : {}),
+        ...(choice.message.refusal != null
+          ? { refusal: choice.message.refusal }
           : {}),
       }
     }
@@ -552,6 +556,7 @@ export class LangtailChatLanguageModel<
     // Track reasoning details to preserve for multi-turn conversations
     const accumulatedReasoningDetails: ReasoningDetailUnion[] = []
     let responseProviderMetadata: MessageProviderMetadata | undefined
+    let accumulatedRefusal = ""
     let hasActiveReasoningText = false
     const enqueueReasoning = (
       controller: TransformStreamDefaultController<LanguageModelV1StreamPart>,
@@ -682,6 +687,10 @@ export class LangtailChatLanguageModel<
             }
 
             const delta = choice.delta
+
+            if (delta.refusal != null) {
+              accumulatedRefusal += delta.refusal
+            }
 
             if (delta.provider_metadata != null) {
               responseProviderMetadata = delta.provider_metadata
@@ -1001,6 +1010,16 @@ export class LangtailChatLanguageModel<
                 responseProviderMetadata as unknown as JSONValue
             }
 
+            if (accumulatedRefusal.length > 0) {
+              if (!providerMetadata) {
+                providerMetadata = {}
+              }
+              if (!providerMetadata.langtail) {
+                providerMetadata.langtail = {}
+              }
+              providerMetadata.langtail.refusal = accumulatedRefusal
+            }
+
             controller.enqueue({
               type: "finish",
               finishReason,
@@ -1053,6 +1072,7 @@ const openaiChatResponseSchema = z.object({
       message: z.object({
         role: z.literal("assistant").nullish(),
         content: z.string().nullish(),
+        refusal: z.string().nullish(),
         reasoning: z
           .union([
             z.string(),
@@ -1140,6 +1160,7 @@ const langtailChatChunksSchema = z.union([
           .object({
             role: z.enum(["assistant"]).nullish(),
             content: z.string().nullish(),
+            refusal: z.string().nullish(),
             reasoning: z
               .union([
                 z.string(),

--- a/src/vercel-ai/langtail-language-model.ts
+++ b/src/vercel-ai/langtail-language-model.ts
@@ -40,6 +40,8 @@ import {
   ReasoningDetailType,
   ReasoningDetailUnion,
 } from "../reasoning-details-schema"
+import { MessageProviderMetadataSchema } from "../schemas"
+import type { MessageProviderMetadata } from "../schemas"
 
 type LangtailChatConfig = {
   provider: string
@@ -447,17 +449,30 @@ export class LangtailChatLanguageModel<
       }
     }
 
-    // Add reasoning_details to providerMetadata for preservation in multi-turn conversations
+    // Preserve provider-specific reasoning data for multi-turn conversations.
     if (
-      choice.message.reasoning_details &&
-      choice.message.reasoning_details.length > 0
+      (choice.message.reasoning_details &&
+        choice.message.reasoning_details.length > 0) ||
+      choice.message.provider_metadata
     ) {
       if (!providerMetadata) {
         providerMetadata = {}
       }
       providerMetadata.langtail = {
-        reasoning_details: choice.message
-          .reasoning_details as ReasoningDetailUnion[],
+        ...((providerMetadata.langtail as Record<string, JSONValue>) ?? {}),
+        ...(choice.message.reasoning_details &&
+        choice.message.reasoning_details.length > 0
+          ? {
+              reasoning_details: choice.message
+                .reasoning_details as ReasoningDetailUnion[],
+            }
+          : {}),
+        ...(choice.message.provider_metadata
+          ? {
+              provider_metadata: choice.message
+                .provider_metadata as unknown as JSONValue,
+            }
+          : {}),
       }
     }
 
@@ -536,6 +551,7 @@ export class LangtailChatLanguageModel<
 
     // Track reasoning details to preserve for multi-turn conversations
     const accumulatedReasoningDetails: ReasoningDetailUnion[] = []
+    let responseProviderMetadata: MessageProviderMetadata | undefined
     let hasActiveReasoningText = false
     const enqueueReasoning = (
       controller: TransformStreamDefaultController<LanguageModelV1StreamPart>,
@@ -666,6 +682,10 @@ export class LangtailChatLanguageModel<
             }
 
             const delta = choice.delta
+
+            if (delta.provider_metadata != null) {
+              responseProviderMetadata = delta.provider_metadata
+            }
 
             if (delta.content != null) {
               controller.enqueue({
@@ -970,6 +990,17 @@ export class LangtailChatLanguageModel<
                 accumulatedReasoningDetails
             }
 
+            if (responseProviderMetadata != null) {
+              if (!providerMetadata) {
+                providerMetadata = {}
+              }
+              if (!providerMetadata.langtail) {
+                providerMetadata.langtail = {}
+              }
+              providerMetadata.langtail.provider_metadata =
+                responseProviderMetadata as unknown as JSONValue
+            }
+
             controller.enqueue({
               type: "finish",
               finishReason,
@@ -1051,6 +1082,7 @@ const openaiChatResponseSchema = z.object({
           .nullish(),
         reasoning_content: z.string().nullish(),
         reasoning_details: ReasoningDetailArraySchema.nullish(),
+        provider_metadata: MessageProviderMetadataSchema.optional(),
         function_call: z
           .object({
             arguments: z.string(),
@@ -1137,6 +1169,7 @@ const langtailChatChunksSchema = z.union([
               .nullish(),
             reasoning_content: z.string().nullish(),
             reasoning_details: ReasoningDetailArraySchema.nullish(),
+            provider_metadata: MessageProviderMetadataSchema.optional(),
             function_call: z
               .object({
                 name: z.string().optional(),

--- a/src/vercel-ai/langtail-language-model.ts
+++ b/src/vercel-ai/langtail-language-model.ts
@@ -450,6 +450,10 @@ export class LangtailChatLanguageModel<
     }
 
     // Preserve provider-specific reasoning data for multi-turn conversations.
+    const refusalAsText =
+      choice.message.refusal != null &&
+      choice.message.refusal.length > 0 &&
+      (choice.message.content == null || choice.message.content.length === 0)
     if (
       (choice.message.reasoning_details &&
         choice.message.reasoning_details.length > 0) ||
@@ -477,11 +481,14 @@ export class LangtailChatLanguageModel<
         ...(choice.message.refusal != null
           ? { refusal: choice.message.refusal }
           : {}),
+        ...(refusalAsText ? { refusal_as_text: true } : {}),
       }
     }
 
     return {
-      text: choice.message.content ?? undefined,
+      text: refusalAsText
+        ? (choice.message.refusal ?? undefined)
+        : (choice.message.content ?? undefined),
       reasoning: reasoningContent,
       toolCalls: choice.message.tool_calls?.map((toolCall) => ({
         toolCallType: "function",
@@ -690,6 +697,12 @@ export class LangtailChatLanguageModel<
 
             if (delta.refusal != null) {
               accumulatedRefusal += delta.refusal
+              if (delta.refusal.length > 0) {
+                controller.enqueue({
+                  type: "text-delta",
+                  textDelta: delta.refusal,
+                })
+              }
             }
 
             if (delta.provider_metadata != null) {
@@ -1018,6 +1031,7 @@ export class LangtailChatLanguageModel<
                 providerMetadata.langtail = {}
               }
               providerMetadata.langtail.refusal = accumulatedRefusal
+              providerMetadata.langtail.refusal_as_text = true
             }
 
             controller.enqueue({

--- a/src/vercel-ai/openai-chat-prompt.ts
+++ b/src/vercel-ai/openai-chat-prompt.ts
@@ -1,4 +1,5 @@
 import { ReasoningDetail } from "../reasoning-details-schema"
+import type { MessageProviderMetadata } from "../schemas"
 
 export type OpenAIChatPrompt = Array<ChatCompletionMessageParam>
 
@@ -38,6 +39,7 @@ export interface ChatCompletionAssistantMessageParam {
   role: "assistant"
   content?: string | null
   reasoning_details?: ReasoningDetail[] | null
+  provider_metadata?: MessageProviderMetadata
   tool_calls?: Array<ChatCompletionMessageToolCall>
 }
 

--- a/src/vercel-ai/openai-chat-prompt.ts
+++ b/src/vercel-ai/openai-chat-prompt.ts
@@ -38,6 +38,7 @@ export interface ChatCompletionContentPartText {
 export interface ChatCompletionAssistantMessageParam {
   role: "assistant"
   content?: string | null
+  refusal?: string | null
   reasoning_details?: ReasoningDetail[] | null
   provider_metadata?: MessageProviderMetadata
   tool_calls?: Array<ChatCompletionMessageToolCall>

--- a/src/vercel-ai/openai-responses-metadata.spec.ts
+++ b/src/vercel-ai/openai-responses-metadata.spec.ts
@@ -1,0 +1,259 @@
+import type { LanguageModelV1StreamPart } from "@ai-sdk/provider"
+import nock from "nock"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { LangtailPrompts } from "../LangtailPrompts"
+import { LangtailChatLanguageModel } from "./langtail-language-model"
+
+const BASE_URL = "https://api.langtail.com"
+
+const responsesProviderMetadata = {
+  openai: {
+    responses: {
+      output_items: [
+        {
+          id: "rs_123",
+          type: "reasoning",
+          encrypted_content: "encrypted-reasoning",
+          summary: [{ type: "summary_text", text: "Checked the inputs." }],
+        },
+        {
+          id: "msg_123",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          phase: "final_answer",
+          content: [
+            {
+              type: "output_text",
+              text: "The answer is 42.",
+              annotations: [],
+            },
+          ],
+        },
+      ],
+    },
+  },
+}
+
+function createModel() {
+  const langtailPrompts = new LangtailPrompts({
+    apiKey: "test-api-key",
+    baseURL: BASE_URL,
+  })
+
+  return new LangtailChatLanguageModel(
+    "test-prompt",
+    {},
+    {
+      provider: "langtail.chat",
+      langtailPrompts,
+      headers: {
+        "X-API-Key": "test-api-key",
+        "content-type": "application/json",
+      },
+    },
+  )
+}
+
+function createSSEResponse(chunks: object[]) {
+  return chunks
+    .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`)
+    .concat("data: [DONE]\n\n")
+    .join("")
+}
+
+async function collectStreamParts(
+  stream: ReadableStream<LanguageModelV1StreamPart>,
+): Promise<LanguageModelV1StreamPart[]> {
+  const parts: LanguageModelV1StreamPart[] = []
+  const reader = stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    parts.push(value)
+  }
+  return parts
+}
+
+describe("OpenAI Responses metadata round-trip", () => {
+  beforeAll(() => {
+    nock.disableNetConnect()
+  })
+
+  afterAll(() => {
+    nock.enableNetConnect()
+    nock.cleanAll()
+  })
+
+  it("preserves output items from a non-streamed response in the next request", async () => {
+    const firstResponse = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/)
+      .reply(200, {
+        id: "chatcmpl-first",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "The answer is 42.",
+              provider_metadata: responsesProviderMetadata,
+            },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      })
+
+    const model = createModel()
+    const result = await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [{ role: "user", content: [{ type: "text", text: "Solve it" }] }],
+    })
+
+    expect(result.providerMetadata?.langtail).toMatchObject({
+      provider_metadata: responsesProviderMetadata,
+      usage: {
+        promptTokens: 10,
+        completionTokens: 5,
+        cachedInputTokens: 0,
+        reasoningTokens: 0,
+      },
+    })
+    firstResponse.done()
+
+    const secondRequest = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/, (body) => {
+        expect(body.messages[0].provider_metadata).toEqual(
+          responsesProviderMetadata,
+        )
+        return true
+      })
+      .reply(200, {
+        id: "chatcmpl-second",
+        choices: [
+          {
+            message: { role: "assistant", content: "Continued." },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 2 },
+      })
+
+    await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: result.text ?? "" }],
+          providerMetadata: result.providerMetadata,
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue" }],
+        },
+      ],
+    })
+    secondRequest.done()
+  })
+
+  it("preserves output items from a streamed response in the next request", async () => {
+    const firstResponse = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/)
+      .reply(
+        200,
+        createSSEResponse([
+          {
+            id: "chatcmpl-first-stream",
+            choices: [
+              {
+                index: 0,
+                delta: { role: "assistant", content: "The answer is 42." },
+              },
+            ],
+          },
+          {
+            id: "chatcmpl-first-stream",
+            choices: [
+              {
+                index: 0,
+                delta: { provider_metadata: responsesProviderMetadata },
+              },
+            ],
+          },
+          {
+            id: "chatcmpl-first-stream",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          },
+        ]),
+        { "content-type": "text/event-stream" },
+      )
+
+    const model = createModel()
+    const { stream } = await model.doStream({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [{ role: "user", content: [{ type: "text", text: "Solve it" }] }],
+    })
+    const parts = await collectStreamParts(stream)
+    const finishPart = parts.find((part) => part.type === "finish")
+
+    expect(finishPart).toMatchObject({
+      type: "finish",
+      providerMetadata: {
+        langtail: {
+          provider_metadata: responsesProviderMetadata,
+          usage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            cachedInputTokens: 0,
+            reasoningTokens: 0,
+          },
+        },
+      },
+    })
+    firstResponse.done()
+
+    const secondRequest = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/, (body) => {
+        expect(body.messages[0].provider_metadata).toEqual(
+          responsesProviderMetadata,
+        )
+        return true
+      })
+      .reply(200, {
+        id: "chatcmpl-second-stream",
+        choices: [
+          {
+            message: { role: "assistant", content: "Continued." },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 2 },
+      })
+
+    await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The answer is 42." }],
+          providerMetadata:
+            finishPart?.type === "finish"
+              ? finishPart.providerMetadata
+              : undefined,
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue" }],
+        },
+      ],
+    })
+    secondRequest.done()
+  })
+})

--- a/src/vercel-ai/openai-responses-metadata.spec.ts
+++ b/src/vercel-ai/openai-responses-metadata.spec.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV1StreamPart } from "@ai-sdk/provider"
+import { generateText, streamText } from "ai"
 import nock from "nock"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { LangtailPrompts } from "../LangtailPrompts"
@@ -165,12 +166,13 @@ describe("OpenAI Responses metadata round-trip", () => {
       })
 
     const model = createModel()
-    const result = await model.doGenerate({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [{ role: "user", content: [{ type: "text", text: "Solve it" }] }],
+    const result = await generateText({
+      model,
+      prompt: "Solve it",
     })
 
+    expect(result.text).toBe("The answer is 42.")
+    expect(result.response.messages).toHaveLength(1)
     expect(result.providerMetadata?.langtail).toMatchObject({
       provider_metadata: responsesProviderMetadata,
       usage: {
@@ -180,6 +182,8 @@ describe("OpenAI Responses metadata round-trip", () => {
         reasoningTokens: 0,
       },
     })
+    const assistantMessage = result.response.messages[0]
+    assistantMessage.providerOptions = result.providerMetadata
     firstResponse.done()
 
     const secondRequest = nock(BASE_URL)
@@ -201,25 +205,14 @@ describe("OpenAI Responses metadata round-trip", () => {
         usage: { prompt_tokens: 20, completion_tokens: 2 },
       })
 
-    await model.doGenerate({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: result.text ?? "" }],
-          providerMetadata: result.providerMetadata,
-        },
-        {
-          role: "user",
-          content: [{ type: "text", text: "Continue" }],
-        },
-      ],
+    await generateText({
+      model,
+      messages: [assistantMessage, { role: "user", content: "Continue" }],
     })
     secondRequest.done()
   })
 
-  it("preserves a non-streamed refusal in the next request", async () => {
+  it("exposes and preserves a non-streamed refusal in the next request", async () => {
     nock(BASE_URL)
       .post(/\/project-prompt\/test-prompt\/production/)
       .reply(200, {
@@ -240,17 +233,32 @@ describe("OpenAI Responses metadata round-trip", () => {
       })
 
     const model = createModel()
-    const result = await model.doGenerate({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [{ role: "user", content: [{ type: "text", text: "Request" }] }],
+    const result = await generateText({
+      model,
+      prompt: "Request",
     })
 
-    expect(result.providerMetadata?.langtail).toMatchObject({ refusal })
+    expect(result.text).toBe(refusal)
+    expect(result.response.messages).toHaveLength(1)
+    expect(result.providerMetadata?.langtail).toMatchObject({
+      refusal,
+      refusal_as_text: true,
+    })
+
+    const assistantMessage = result.response.messages[0]
+    expect(assistantMessage).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: refusal }],
+    })
+    assistantMessage.providerOptions = result.providerMetadata
 
     const secondRequest = nock(BASE_URL)
       .post(/\/project-prompt\/test-prompt\/production/, (body) => {
         expect(body.messages[0].refusal).toBe(refusal)
+        expect(body.messages[0].content).toBe("")
+        expect(body.messages[0].provider_metadata).toEqual(
+          refusalProviderMetadata,
+        )
         return true
       })
       .reply(200, {
@@ -265,17 +273,9 @@ describe("OpenAI Responses metadata round-trip", () => {
         usage: { prompt_tokens: 20, completion_tokens: 2 },
       })
 
-    await model.doGenerate({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [
-        {
-          role: "assistant",
-          content: [],
-          providerMetadata: result.providerMetadata,
-        },
-        { role: "user", content: [{ type: "text", text: "Continue" }] },
-      ],
+    await generateText({
+      model,
+      messages: [assistantMessage, { role: "user", content: "Continue" }],
     })
     secondRequest.done()
   })
@@ -378,7 +378,7 @@ describe("OpenAI Responses metadata round-trip", () => {
     secondRequest.done()
   })
 
-  it("preserves a streamed refusal in the next request", async () => {
+  it("exposes and preserves a streamed refusal in the next request", async () => {
     nock(BASE_URL)
       .post(/\/project-prompt\/test-prompt\/production/)
       .reply(
@@ -407,22 +407,38 @@ describe("OpenAI Responses metadata round-trip", () => {
       )
 
     const model = createModel()
-    const { stream } = await model.doStream({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [{ role: "user", content: [{ type: "text", text: "Request" }] }],
+    const result = streamText({
+      model,
+      prompt: "Request",
     })
-    const parts = await collectStreamParts(stream)
-    const finishPart = parts.find((part) => part.type === "finish")
+    await result.consumeStream()
+    const [text, response, providerMetadata] = await Promise.all([
+      result.text,
+      result.response,
+      result.providerMetadata,
+    ])
 
-    expect(finishPart).toMatchObject({
-      type: "finish",
-      providerMetadata: { langtail: { refusal } },
+    expect(text).toBe(refusal)
+    expect(response.messages).toHaveLength(1)
+    expect(providerMetadata?.langtail).toMatchObject({
+      refusal,
+      refusal_as_text: true,
     })
+
+    const assistantMessage = response.messages[0]
+    expect(assistantMessage).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: refusal }],
+    })
+    assistantMessage.providerOptions = providerMetadata
 
     const secondRequest = nock(BASE_URL)
       .post(/\/project-prompt\/test-prompt\/production/, (body) => {
         expect(body.messages[0].refusal).toBe(refusal)
+        expect(body.messages[0].content).toBe("")
+        expect(body.messages[0].provider_metadata).toEqual(
+          refusalProviderMetadata,
+        )
         return true
       })
       .reply(200, {
@@ -437,20 +453,9 @@ describe("OpenAI Responses metadata round-trip", () => {
         usage: { prompt_tokens: 20, completion_tokens: 2 },
       })
 
-    await model.doGenerate({
-      inputFormat: "prompt",
-      mode: { type: "regular" },
-      prompt: [
-        {
-          role: "assistant",
-          content: [],
-          providerMetadata:
-            finishPart?.type === "finish"
-              ? finishPart.providerMetadata
-              : undefined,
-        },
-        { role: "user", content: [{ type: "text", text: "Continue" }] },
-      ],
+    await generateText({
+      model,
+      messages: [assistantMessage, { role: "user", content: "Continue" }],
     })
     secondRequest.done()
   })

--- a/src/vercel-ai/openai-responses-metadata.spec.ts
+++ b/src/vercel-ai/openai-responses-metadata.spec.ts
@@ -471,6 +471,22 @@ describe("OpenAI Responses metadata round-trip", () => {
     })
   })
 
+  it("keeps the original function-call arguments when object keys are reordered", () => {
+    const rawArguments = '{ "latitude": 50, "longitude": 14 }'
+    const messages = convertToolCallWithMetadata({
+      args: { longitude: 14, latitude: 50 },
+      rawArguments,
+    })
+
+    expect(messages[0]).toMatchObject({
+      tool_calls: [
+        {
+          function: { arguments: rawArguments },
+        },
+      ],
+    })
+  })
+
   it("does not restore original function-call arguments after they change", () => {
     const messages = convertToolCallWithMetadata({
       args: { city: "Brno" },

--- a/src/vercel-ai/openai-responses-metadata.spec.ts
+++ b/src/vercel-ai/openai-responses-metadata.spec.ts
@@ -2,6 +2,7 @@ import type { LanguageModelV1StreamPart } from "@ai-sdk/provider"
 import nock from "nock"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { LangtailPrompts } from "../LangtailPrompts"
+import { convertToOpenAIChatMessages } from "./convert-to-openai-chat-messages"
 import { LangtailChatLanguageModel } from "./langtail-language-model"
 
 const BASE_URL = "https://api.langtail.com"
@@ -29,6 +30,23 @@ const responsesProviderMetadata = {
               annotations: [],
             },
           ],
+        },
+      ],
+    },
+  },
+}
+
+const refusal = "I cannot help with that request."
+const refusalProviderMetadata = {
+  openai: {
+    responses: {
+      output_items: [
+        {
+          id: "msg_refusal",
+          type: "message",
+          role: "assistant",
+          status: "completed",
+          content: [{ type: "refusal", refusal }],
         },
       ],
     },
@@ -73,6 +91,48 @@ async function collectStreamParts(
     parts.push(value)
   }
   return parts
+}
+
+function convertToolCallWithMetadata({
+  args,
+  rawArguments,
+}: {
+  args: Record<string, unknown>
+  rawArguments: string
+}) {
+  return convertToOpenAIChatMessages({
+    prompt: [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_weather",
+            toolName: "get_weather",
+            args,
+          },
+        ],
+        providerMetadata: {
+          langtail: {
+            provider_metadata: {
+              openai: {
+                responses: {
+                  output_items: [
+                    {
+                      type: "function_call",
+                      call_id: "call_weather",
+                      name: "get_weather",
+                      arguments: rawArguments,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  })
 }
 
 describe("OpenAI Responses metadata round-trip", () => {
@@ -154,6 +214,67 @@ describe("OpenAI Responses metadata round-trip", () => {
           role: "user",
           content: [{ type: "text", text: "Continue" }],
         },
+      ],
+    })
+    secondRequest.done()
+  })
+
+  it("preserves a non-streamed refusal in the next request", async () => {
+    nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/)
+      .reply(200, {
+        id: "chatcmpl-refusal",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              refusal,
+              provider_metadata: refusalProviderMetadata,
+            },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      })
+
+    const model = createModel()
+    const result = await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [{ role: "user", content: [{ type: "text", text: "Request" }] }],
+    })
+
+    expect(result.providerMetadata?.langtail).toMatchObject({ refusal })
+
+    const secondRequest = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/, (body) => {
+        expect(body.messages[0].refusal).toBe(refusal)
+        return true
+      })
+      .reply(200, {
+        id: "chatcmpl-after-refusal",
+        choices: [
+          {
+            message: { role: "assistant", content: "Continued." },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 2 },
+      })
+
+    await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [
+        {
+          role: "assistant",
+          content: [],
+          providerMetadata: result.providerMetadata,
+        },
+        { role: "user", content: [{ type: "text", text: "Continue" }] },
       ],
     })
     secondRequest.done()
@@ -255,5 +376,113 @@ describe("OpenAI Responses metadata round-trip", () => {
       ],
     })
     secondRequest.done()
+  })
+
+  it("preserves a streamed refusal in the next request", async () => {
+    nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/)
+      .reply(
+        200,
+        createSSEResponse([
+          {
+            id: "chatcmpl-refusal-stream",
+            choices: [{ index: 0, delta: { refusal } }],
+          },
+          {
+            id: "chatcmpl-refusal-stream",
+            choices: [
+              {
+                index: 0,
+                delta: { provider_metadata: refusalProviderMetadata },
+              },
+            ],
+          },
+          {
+            id: "chatcmpl-refusal-stream",
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 5 },
+          },
+        ]),
+        { "content-type": "text/event-stream" },
+      )
+
+    const model = createModel()
+    const { stream } = await model.doStream({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [{ role: "user", content: [{ type: "text", text: "Request" }] }],
+    })
+    const parts = await collectStreamParts(stream)
+    const finishPart = parts.find((part) => part.type === "finish")
+
+    expect(finishPart).toMatchObject({
+      type: "finish",
+      providerMetadata: { langtail: { refusal } },
+    })
+
+    const secondRequest = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/, (body) => {
+        expect(body.messages[0].refusal).toBe(refusal)
+        return true
+      })
+      .reply(200, {
+        id: "chatcmpl-after-refusal-stream",
+        choices: [
+          {
+            message: { role: "assistant", content: "Continued." },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 2 },
+      })
+
+    await model.doGenerate({
+      inputFormat: "prompt",
+      mode: { type: "regular" },
+      prompt: [
+        {
+          role: "assistant",
+          content: [],
+          providerMetadata:
+            finishPart?.type === "finish"
+              ? finishPart.providerMetadata
+              : undefined,
+        },
+        { role: "user", content: [{ type: "text", text: "Continue" }] },
+      ],
+    })
+    secondRequest.done()
+  })
+
+  it("keeps the original function-call arguments when they match semantically", () => {
+    const rawArguments = '{ "city": "Prague" }'
+    const messages = convertToolCallWithMetadata({
+      args: { city: "Prague" },
+      rawArguments,
+    })
+
+    expect(messages[0]).toMatchObject({
+      tool_calls: [
+        {
+          function: { arguments: rawArguments },
+        },
+      ],
+    })
+  })
+
+  it("does not restore original function-call arguments after they change", () => {
+    const messages = convertToolCallWithMetadata({
+      args: { city: "Brno" },
+      rawArguments: '{ "city": "Prague" }',
+    })
+
+    expect(messages[0]).toMatchObject({
+      tool_calls: [
+        {
+          function: { arguments: '{"city":"Brno"}' },
+        },
+      ],
+    })
   })
 })


### PR DESCRIPTION
## What

- preserve `provider_metadata.openai.responses.output_items` in Langtail message schemas
- expose the metadata through `providerMetadata.langtail` for Vercel AI SDK responses
- send the exact output items back on subsequent assistant messages
- preserve `part_index` in `reasoning_details` as a fallback path
- preserve Responses refusals in both streamed and non-streamed continuations
- retain the original function-call argument string when it still matches the current tool call semantically

This keeps the full Responses output history needed for stateless reasoning continuation, including encrypted reasoning, assistant phase, refusals, and exact function-call items, without upgrading the OpenAI SDK.

Official guidance: https://developers.openai.com/api/docs/guides/reasoning#preserve-reasoning-without-stored-responses

## Verification

- red/green non-stream output-item round-trip test
- red/green streaming output-item round-trip test
- red/green streamed and non-streamed refusal continuation tests
- red/green raw function-call argument test, including a guard against restoring changed arguments
- MessageSchema metadata and refusal preservation test
- `pnpm exec vitest run --exclude src/openai.spec.ts --cache=false` — 117 passed, 8 skipped
- `pnpm run ts`
- `pnpm run build`

`src/openai.spec.ts` remains a credential-dependent live test and cannot load without `LANGTAIL_API_KEY`.