### PR TITLE
Add OpenAI explicit prompt caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.19
+
+- Add complete OpenAI explicit prompt caching support, including request-wide `prompt_cache_key` and `prompt_cache_options` fields and content-block `prompt_cache_breakpoint` markers with strict validation.
+- Map Vercel AI SDK `providerOptions.openai.promptCacheBreakpoint` metadata to the final cacheable system or user content block without affecting Anthropic cache control.
+- Expose OpenAI `cache_write_tokens` as `providerMetadata.langtail.usage.cacheWriteInputTokens` for both generated and streamed responses.
+
 ## 0.16.18
 
 - Preserve OpenAI Responses reasoning metadata across tool steps in the Vercel AI bridge. The response's `provider_metadata` (including encrypted reasoning items) is now carried on `providerMetadata.langtail.provider_metadata` and replayed on the next request, so OpenAI reasoning models can continue a multi-step conversation. See the new "OpenAI reasoning across tool steps" section in the README for how to attach it when using `maxSteps`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.16.18",
+  "version": "0.16.19",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",

--- a/src/getOpenAIBody.test.ts
+++ b/src/getOpenAIBody.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { getOpenAIBody } from "./getOpenAIBody"
+import { bothBodySchema } from "./schemas"
 
 describe("getOpenAIBody", () => {
   const parsedBody = {
@@ -93,6 +94,132 @@ describe("getOpenAIBody", () => {
     ])
   })
 
+  it("preserves explicit prompt cache request fields and content breakpoints", () => {
+    const parsedCacheBody = bothBodySchema.parse({
+      prompt_cache_key: "chat:test:main",
+      prompt_cache_options: {
+        mode: "explicit",
+        ttl: "30m",
+      },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Describe this image",
+              prompt_cache_breakpoint: { mode: "explicit" },
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: "https://example.com/image.png",
+                detail: "high",
+              },
+              prompt_cache_breakpoint: { mode: "explicit" },
+            },
+          ],
+          provider_metadata: {
+            openai: {
+              responses: {
+                output_items: [
+                  {
+                    id: "rs_123",
+                    type: "reasoning",
+                    encrypted_content: "encrypted-reasoning",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    })
+
+    const openAIbody = getOpenAIBody(
+      {
+        state: {
+          type: "chat",
+          args: {
+            model: "gpt-5.6",
+            max_tokens: 100,
+            temperature: 0.8,
+            top_p: 1,
+            presence_penalty: 0,
+            frequency_penalty: 0,
+            jsonmode: false,
+            seed: null,
+            stop: [],
+          },
+          template: [],
+        },
+        chatInput: {},
+      },
+      parsedCacheBody,
+    )
+
+    expect(openAIbody).toMatchObject({
+      prompt_cache_key: "chat:test:main",
+      prompt_cache_options: {
+        mode: "explicit",
+        ttl: "30m",
+      },
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Describe this image",
+              prompt_cache_breakpoint: { mode: "explicit" },
+            },
+            {
+              type: "image_url",
+              image_url: {
+                url: "https://example.com/image.png",
+                detail: "high",
+              },
+              prompt_cache_breakpoint: { mode: "explicit" },
+            },
+          ],
+        },
+      ],
+    })
+    expect(openAIbody.messages[0]).not.toHaveProperty("provider_metadata")
+  })
+
+  it.each([
+    {
+      name: "request mode",
+      body: { prompt_cache_options: { mode: "automatic" } },
+    },
+    {
+      name: "request TTL",
+      body: {
+        prompt_cache_options: { mode: "explicit", ttl: "1h" },
+      },
+    },
+    {
+      name: "content breakpoint mode",
+      body: {
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Hello",
+                prompt_cache_breakpoint: { mode: "implicit" },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ])("rejects an invalid prompt cache $name", ({ body }) => {
+    expect(bothBodySchema.safeParse(body).success).toBe(false)
+  })
+
   it("should extend variables from playground", () => {
     const completionConfig = {
       state: {
@@ -166,7 +293,6 @@ describe("getOpenAIBody", () => {
     `)
   })
 
-
   it("should add parallel_tool_calls param when it is set in parsedBody", () => {
     const completionConfig = {
       state: {
@@ -196,7 +322,7 @@ describe("getOpenAIBody", () => {
       parallelToolCalls: true,
     })
 
-    expect(openAIbody).toHaveProperty('parallel_tool_calls', true)
+    expect(openAIbody).toHaveProperty("parallel_tool_calls", true)
   })
 
   it("should override parameters from the playground with the ones in parsedBody", () => {
@@ -329,9 +455,8 @@ describe("getOpenAIBody", () => {
     `) // template is overridden by the one in parsedBody
   })
 
-
-  describe('thread messages', () => {
-    it('should compile thread messages with passed variables', () => {
+  describe("thread messages", () => {
+    it("should compile thread messages with passed variables", () => {
       const completionConfig = {
         state: {
           type: "chat" as const,
@@ -351,24 +476,29 @@ describe("getOpenAIBody", () => {
               role: "user" as const,
               content: "TEAMPLTE: This use previous user message.",
             },
-          ]
+          ],
         },
         chatInput: {},
       }
 
-      const openAIbody = getOpenAIBody(completionConfig, {
-        variables: {
-          footballClub: "Slavia Praha",
-        },
-        messages: [],
-      }, {
-        threadMessages: [
-          {
-            role: "system" as const,
-            content: "THREAD: Your favourite football club is {{ footballClub }}",
+      const openAIbody = getOpenAIBody(
+        completionConfig,
+        {
+          variables: {
+            footballClub: "Slavia Praha",
           },
-        ]
-      })
+          messages: [],
+        },
+        {
+          threadMessages: [
+            {
+              role: "system" as const,
+              content:
+                "THREAD: Your favourite football club is {{ footballClub }}",
+            },
+          ],
+        },
+      )
 
       expect(openAIbody).toMatchInlineSnapshot(`
         {
@@ -392,7 +522,7 @@ describe("getOpenAIBody", () => {
       `)
     })
 
-    it('should combine template messages with other messages', () => {
+    it("should combine template messages with other messages", () => {
       const completionConfig = {
         state: {
           type: "chat" as const,
@@ -410,26 +540,32 @@ describe("getOpenAIBody", () => {
           template: [
             {
               role: "system" as const,
-              content: "TEMPLATE MESSAGE: This use previous user message. With variable {{ footballClub }}",
+              content:
+                "TEMPLATE MESSAGE: This use previous user message. With variable {{ footballClub }}",
             },
-          ]
+          ],
         },
         chatInput: {
           footballClub: "Sparta Praha",
         },
       }
 
-      const openAIbody = getOpenAIBody(completionConfig, {
-        variables: {},
-        messages: [],
-      }, {
-        threadMessages: [
-          {
-            role: "user" as const,
-            content: "THREAD message: Your favourite football club is NOT SPARTA",
-          },
-        ]
-      })
+      const openAIbody = getOpenAIBody(
+        completionConfig,
+        {
+          variables: {},
+          messages: [],
+        },
+        {
+          threadMessages: [
+            {
+              role: "user" as const,
+              content:
+                "THREAD message: Your favourite football club is NOT SPARTA",
+            },
+          ],
+        },
+      )
 
       expect(openAIbody).toMatchInlineSnapshot(`
         {
@@ -453,7 +589,7 @@ describe("getOpenAIBody", () => {
       `)
     })
 
-    it('should NOT compile thread messages with variables', () => {
+    it("should NOT compile thread messages with variables", () => {
       const completionConfig = {
         state: {
           type: "chat" as const,
@@ -468,24 +604,29 @@ describe("getOpenAIBody", () => {
             seed: null,
             stop: [],
           },
-          template: []
+          template: [],
         },
         chatInput: {
           footballClub: "Sparta Praha",
         },
       }
 
-      const openAIbody = getOpenAIBody(completionConfig, {
-        variables: {},
-        messages: [],
-      }, {
-        threadMessages: [
-          {
-            role: "user" as const,
-            content: "THREAD message: Your favourite football club is {{ footballClub }}",
-          },
-        ]
-      })
+      const openAIbody = getOpenAIBody(
+        completionConfig,
+        {
+          variables: {},
+          messages: [],
+        },
+        {
+          threadMessages: [
+            {
+              role: "user" as const,
+              content:
+                "THREAD message: Your favourite football club is {{ footballClub }}",
+            },
+          ],
+        },
+      )
 
       expect(openAIbody).toMatchInlineSnapshot(`
         {

--- a/src/getOpenAIBody.ts
+++ b/src/getOpenAIBody.ts
@@ -1,16 +1,19 @@
-
 import type OpenAI from "openai"
 
 import { compileLTTemplate } from "./template"
-import { ChatCompletionsCreateParams, PlaygroundMessage } from "./schemas"
+import {
+  ChatCompletionsCreateParams,
+  PlaygroundMessage,
+  PromptCacheOptions,
+} from "./schemas"
 import { IncomingBodyType, PlaygroundState } from "./schemas"
 import { ChatCompletionMessageParam } from "openai/resources"
 
 function stripProviderMetadata(
   message: ChatCompletionMessageParam,
 ): ChatCompletionMessageParam {
-  const { provider_metadata: _, ...chatCompletionMessage } = message as
-    ChatCompletionMessageParam & { provider_metadata?: unknown }
+  const { provider_metadata: _, ...chatCompletionMessage } =
+    message as ChatCompletionMessageParam & { provider_metadata?: unknown }
   return chatCompletionMessage as ChatCompletionMessageParam
 }
 
@@ -46,23 +49,41 @@ export function getOpenAIBody(
 ): ChatCompletionsCreateParams {
   const completionArgs = completionConfig.state.args
 
-  const reasoningEffort = parsedBody.reasoning_effort ?? completionArgs.reasoning_effort
+  const reasoningEffort =
+    parsedBody.reasoning_effort ?? completionArgs.reasoning_effort
   const template = parsedBody.template ?? completionConfig.state.template
-  const compiledTemplate = compileMessages(template, Object.assign(
-    completionConfig.chatInput,
-    parsedBody.variables ?? {},
-  ))
+  const compiledTemplate = compileMessages(
+    template,
+    Object.assign(completionConfig.chatInput, parsedBody.variables ?? {}),
+  )
   const bodyMessages = [
-    ...[...(threadParams?.threadMessages ?? []) as ChatCompletionMessageParam[]],
-    ...(parsedBody.messages ?? []) as ChatCompletionMessageParam[]
+    ...[
+      ...((threadParams?.threadMessages ?? []) as ChatCompletionMessageParam[]),
+    ],
+    ...((parsedBody.messages ?? []) as ChatCompletionMessageParam[]),
   ]
 
-  const inputMessages = options?.appendTemplate ? [...bodyMessages, ...compiledTemplate] : [...compiledTemplate, ...bodyMessages]
+  const inputMessages = options?.appendTemplate
+    ? [...bodyMessages, ...compiledTemplate]
+    : [...compiledTemplate, ...bodyMessages]
 
-  const openAIbody: Omit<OpenAI.Chat.ChatCompletionCreateParams, 'stream' | 'reasoning_effort'> & { reasoning_effort?: string } = {
+  const openAIbody: Omit<
+    OpenAI.Chat.ChatCompletionCreateParams,
+    "stream" | "reasoning_effort"
+  > & {
+    reasoning_effort?: string
+    prompt_cache_key?: string
+    prompt_cache_options?: PromptCacheOptions
+  } = {
     model: parsedBody.model ?? completionArgs.model,
     temperature: parsedBody.temperature ?? completionArgs.temperature,
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    ...(parsedBody.prompt_cache_key !== undefined
+      ? { prompt_cache_key: parsedBody.prompt_cache_key }
+      : {}),
+    ...(parsedBody.prompt_cache_options !== undefined
+      ? { prompt_cache_options: parsedBody.prompt_cache_options }
+      : {}),
     messages: inputMessages.map(stripProviderMetadata),
     top_p: parsedBody.top_p ?? completionArgs.top_p,
     ...(parsedBody.parallelToolCalls !== undefined
@@ -74,14 +95,18 @@ export function getOpenAIBody(
       parsedBody.frequency_penalty ?? completionArgs.frequency_penalty,
     ...(parsedBody.seed || completionArgs.seed
       ? {
-        seed: parsedBody.seed ?? completionArgs.seed,
-      }
+          seed: parsedBody.seed ?? completionArgs.seed,
+        }
       : {}),
     ...(Array.isArray(completionArgs.stop) && completionArgs.stop.length > 0
       ? { stop: completionArgs.stop }
       : {}),
     ...(parsedBody.max_thinking_tokens || completionArgs.max_thinking_tokens
-      ? { max_thinking_tokens: parsedBody.max_thinking_tokens ?? completionArgs.max_thinking_tokens }
+      ? {
+          max_thinking_tokens:
+            parsedBody.max_thinking_tokens ??
+            completionArgs.max_thinking_tokens,
+        }
       : {}),
   }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -13,9 +13,27 @@ export interface ILangtailExtraProps {
   metadata?: Record<string, string>
 }
 
+export type PromptCacheOptions = {
+  mode: "implicit" | "explicit"
+  ttl?: "30m"
+}
+
+export type PromptCacheBreakpoint = {
+  mode: "explicit"
+}
+
+export type OpenAIRequestCacheFields = {
+  prompt_cache_key?: string
+  prompt_cache_options?: PromptCacheOptions
+}
+
 export type ChatCompletionsCreateParams =
-  | (ChatCompletionCreateParamsStreaming & ILangtailExtraProps)
-  | (ChatCompletionCreateParamsNonStreaming & ILangtailExtraProps)
+  | (ChatCompletionCreateParamsStreaming &
+      ILangtailExtraProps &
+      OpenAIRequestCacheFields)
+  | (ChatCompletionCreateParamsNonStreaming &
+      ILangtailExtraProps &
+      OpenAIRequestCacheFields)
 
 export interface ChatState {
   type: "chat"
@@ -78,6 +96,7 @@ export interface CompletionState {
 export interface ContentItemText {
   type: "text"
   text: string
+  prompt_cache_breakpoint?: PromptCacheBreakpoint
 }
 
 export interface ContentItemImage {
@@ -86,6 +105,7 @@ export interface ContentItemImage {
     url: string
     detail?: "auto" | "low" | "high"
   }
+  prompt_cache_breakpoint?: PromptCacheBreakpoint
 }
 
 export interface ContentItemGeminiMediaUrl {
@@ -171,9 +191,23 @@ export interface Deployment<P extends PromptSlug> {
   version?: Version<P, Environment<P>> & string
 }
 
+export const PromptCacheOptionsSchema = z
+  .object({
+    mode: z.enum(["implicit", "explicit"]),
+    ttl: z.literal("30m").optional(),
+  })
+  .strict() satisfies z.ZodType<PromptCacheOptions>
+
+export const PromptCacheBreakpointSchema = z
+  .object({
+    mode: z.literal("explicit"),
+  })
+  .strict() satisfies z.ZodType<PromptCacheBreakpoint>
+
 export const ContentItemTextSchema = z.object({
   type: z.literal("text"),
   text: z.string(),
+  prompt_cache_breakpoint: PromptCacheBreakpointSchema.optional(),
 }) satisfies z.ZodType<ContentItemText>
 
 export const ContentItemImageSchema = z.object({
@@ -182,6 +216,7 @@ export const ContentItemImageSchema = z.object({
     url: z.string(),
     detail: z.enum(["auto", "low", "high"]).default("auto"),
   }),
+  prompt_cache_breakpoint: PromptCacheBreakpointSchema.optional(),
 }) satisfies z.ZodType<ContentItemImage>
 
 export const ContentItemGeminiMediaUrlSchema = z.object({
@@ -303,12 +338,16 @@ export const langtailBodySchema = z.object({
 export const openAIBodySchemaObjectDefinition = {
   stream: z.boolean().optional(),
   user: z.string().optional(),
+  prompt_cache_key: z.string().optional(),
+  prompt_cache_options: PromptCacheOptionsSchema.optional(),
 
   seed: z.number().optional(),
   max_tokens: z.number().optional(),
   max_thinking_tokens: z.number().optional(),
   temperature: z.number().optional(),
-  reasoning_effort: z.enum(["minimal", "low", "medium", "high", "max"]).optional(),
+  reasoning_effort: z
+    .enum(["minimal", "low", "medium", "high", "max"])
+    .optional(),
   top_p: z.number().optional(),
   parallel_tool_calls: z.boolean().optional(),
   presence_penalty: z.number().optional(),

--- a/src/vercel-ai/convert-to-openai-chat-messages.spec.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import type { LanguageModelV1Prompt } from "@ai-sdk/provider"
+import { convertToOpenAIChatMessages } from "./convert-to-openai-chat-messages"
+
+describe("convertToOpenAIChatMessages explicit prompt caching", () => {
+  it("converts a marked system string to a text content block", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "system",
+        content: "Stable instructions",
+        providerMetadata: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: "Stable instructions",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ])
+  })
+
+  it("marks only the final text or image block in a multipart user message", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this image" },
+          {
+            type: "image",
+            image: new URL("https://example.com/image.png"),
+            mimeType: "image/png",
+          },
+        ],
+        providerMetadata: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "Describe this image",
+          },
+          {
+            type: "image_url",
+            image_url: {
+              url: "https://example.com/image.png",
+            },
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ])
+  })
+
+  it("leaves unmarked content and Anthropic cache control unchanged", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "system",
+        content: "Cached by Anthropic",
+        providerMetadata: {
+          anthropic: {
+            cacheControl: { type: "ephemeral", ttl: "1h" },
+          },
+        },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Unmarked OpenAI message" }],
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "system",
+        content: "Cached by Anthropic",
+        cache_enabled: true,
+        cache_ttl: "1h",
+      },
+      {
+        role: "user",
+        content: "Unmarked OpenAI message",
+      },
+    ])
+  })
+})

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -7,7 +7,11 @@ import {
   OpenAIChatPrompt,
   ChatCompletionContentPart,
 } from "./openai-chat-prompt"
-import type { MessageProviderMetadata, MessageReasoning } from "../schemas"
+import type {
+  MessageProviderMetadata,
+  MessageReasoning,
+  PromptCacheBreakpoint,
+} from "../schemas"
 import { ReasoningDetail } from "../reasoning-details-schema"
 
 function areJsonValuesEqual(left: unknown, right: unknown): boolean {
@@ -110,6 +114,8 @@ export function convertToOpenAIChatMessages({
 
   for (const { role, content, providerMetadata } of prompt) {
     const anthropicCacheControl = providerMetadata?.anthropic?.cacheControl
+    const promptCacheBreakpoint = providerMetadata?.openai
+      ?.promptCacheBreakpoint as PromptCacheBreakpoint | undefined
     const cacheEnabled = Boolean(anthropicCacheControl)
     const cacheTtl =
       typeof anthropicCacheControl === "object" &&
@@ -119,51 +125,94 @@ export function convertToOpenAIChatMessages({
 
     switch (role) {
       case "system": {
-        addMessage({ role: "system", content }, cacheEnabled, cacheTtl)
+        addMessage(
+          {
+            role: "system",
+            content:
+              promptCacheBreakpoint === undefined
+                ? content
+                : [
+                    {
+                      type: "text",
+                      text: content,
+                      prompt_cache_breakpoint: promptCacheBreakpoint,
+                    },
+                  ],
+          },
+          cacheEnabled,
+          cacheTtl,
+        )
         break
       }
 
       case "user": {
         if (content.length === 1 && content[0].type === "text") {
           addMessage(
-            { role: "user", content: content[0].text },
+            {
+              role: "user",
+              content:
+                promptCacheBreakpoint === undefined
+                  ? content[0].text
+                  : [
+                      {
+                        type: "text",
+                        text: content[0].text,
+                        prompt_cache_breakpoint: promptCacheBreakpoint,
+                      },
+                    ],
+            },
             cacheEnabled,
             cacheTtl,
           )
           break
         }
 
+        const convertedContent: ChatCompletionContentPart[] = content.map(
+          (part) => {
+            switch (part.type) {
+              case "text": {
+                return { type: "text", text: part.text }
+              }
+              case "image": {
+                return {
+                  type: "image_url",
+                  image_url: {
+                    url:
+                      part.image instanceof URL
+                        ? part.image.toString()
+                        : `data:${
+                            part.mimeType ?? "image/jpeg"
+                          };base64,${convertUint8ArrayToBase64(part.image)}`,
+
+                    // OpenAI specific extension: image detail
+                    detail: part.providerMetadata?.openai?.imageDetail as
+                      | "auto"
+                      | "low"
+                      | "high"
+                      | undefined,
+                  },
+                }
+              }
+              case "file": {
+                throw new UnsupportedFunctionalityError({
+                  functionality: "File content parts in user messages",
+                })
+              }
+            }
+          },
+        )
+
+        if (promptCacheBreakpoint !== undefined) {
+          const finalContentPart = convertedContent[convertedContent.length - 1]
+          if (finalContentPart !== undefined) {
+            finalContentPart.prompt_cache_breakpoint = promptCacheBreakpoint
+          }
+        }
+
         addMessage(
           {
             role: "user",
-            content: content.map((part) => {
-              switch (part.type) {
-                case "text": {
-                  return { type: "text", text: part.text }
-                }
-                case "image": {
-                  return {
-                    type: "image_url",
-                    image_url: {
-                      url:
-                        part.image instanceof URL
-                          ? part.image.toString()
-                          : `data:${
-                              part.mimeType ?? "image/jpeg"
-                            };base64,${convertUint8ArrayToBase64(part.image)}`,
-
-                      // OpenAI specific extension: image detail
-                      detail: part.providerMetadata?.openai?.imageDetail,
-                    },
-                  }
-                }
-                case "file": {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: "File content parts in user messages",
-                  })
-                }
-              }
-            }),
+            content: convertedContent,
           },
           cacheEnabled,
           cacheTtl,

--- a/src/vercel-ai/langtail-language-model-usage.spec.ts
+++ b/src/vercel-ai/langtail-language-model-usage.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, beforeAll, afterAll } from "vitest"
 import nock from "nock"
+import { generateText } from "ai"
 import { LangtailChatLanguageModel } from "./langtail-language-model"
 import { LangtailPrompts } from "../LangtailPrompts"
 import type { LanguageModelV1StreamPart } from "@ai-sdk/provider"
@@ -12,20 +13,29 @@ function createModel() {
     baseURL: BASE_URL,
   })
 
-  return new LangtailChatLanguageModel("test-prompt", {}, {
-    provider: "langtail.chat",
-    langtailPrompts,
-    headers: {
-      "X-API-Key": "test-api-key",
-      "content-type": "application/json",
+  return new LangtailChatLanguageModel(
+    "test-prompt",
+    {},
+    {
+      provider: "langtail.chat",
+      langtailPrompts,
+      headers: {
+        "X-API-Key": "test-api-key",
+        "content-type": "application/json",
+      },
     },
-  })
+  )
 }
 
 const defaultCallOptions = {
   inputFormat: "prompt" as const,
   mode: { type: "regular" as const },
-  prompt: [{ role: "user" as const, content: [{ type: "text" as const, text: "Hello" }] }],
+  prompt: [
+    {
+      role: "user" as const,
+      content: [{ type: "text" as const, text: "Hello" }],
+    },
+  ],
 }
 
 describe("Adaptive thinking and reasoning_effort", () => {
@@ -65,11 +75,13 @@ describe("Adaptive thinking and reasoning_effort", () => {
       })
       .reply(200, {
         id: "chatcmpl-123",
-        choices: [{
-          message: { role: "assistant", content: "Hello!" },
-          finish_reason: "stop",
-          index: 0,
-        }],
+        choices: [
+          {
+            message: { role: "assistant", content: "Hello!" },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
         usage: { prompt_tokens: 10, completion_tokens: 5 },
       })
 
@@ -87,11 +99,13 @@ describe("Adaptive thinking and reasoning_effort", () => {
       })
       .reply(200, {
         id: "chatcmpl-123",
-        choices: [{
-          message: { role: "assistant", content: "Hello!" },
-          finish_reason: "stop",
-          index: 0,
-        }],
+        choices: [
+          {
+            message: { role: "assistant", content: "Hello!" },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
         usage: { prompt_tokens: 10, completion_tokens: 5 },
       })
 
@@ -116,11 +130,13 @@ describe("Adaptive thinking and reasoning_effort", () => {
       })
       .reply(200, {
         id: "chatcmpl-123",
-        choices: [{
-          message: { role: "assistant", content: "Hello!" },
-          finish_reason: "stop",
-          index: 0,
-        }],
+        choices: [
+          {
+            message: { role: "assistant", content: "Hello!" },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
         usage: { prompt_tokens: 10, completion_tokens: 5 },
       })
 
@@ -131,6 +147,88 @@ describe("Adaptive thinking and reasoning_effort", () => {
           thinking: { type: "enabled", budgetTokens: 1025 },
         },
       },
+    })
+    scope.done()
+  })
+})
+
+describe("Explicit prompt caching request", () => {
+  beforeAll(() => {
+    nock.disableNetConnect()
+  })
+
+  afterAll(() => {
+    nock.enableNetConnect()
+    nock.cleanAll()
+  })
+
+  it("forwards request settings and message breakpoints to Langtail", async () => {
+    const langtailPrompts = new LangtailPrompts({
+      apiKey: "test-api-key",
+      baseURL: BASE_URL,
+    })
+    const model = new LangtailChatLanguageModel(
+      "test-prompt",
+      {
+        prompt_cache_key: "chat:test:main",
+        prompt_cache_options: { mode: "explicit", ttl: "30m" },
+      },
+      {
+        provider: "langtail.chat",
+        langtailPrompts,
+        headers: {
+          "X-API-Key": "test-api-key",
+          "content-type": "application/json",
+        },
+      },
+    )
+
+    const scope = nock(BASE_URL)
+      .post(/\/project-prompt\/test-prompt\/production/, (body) => {
+        expect(body.prompt_cache_key).toBe("chat:test:main")
+        expect(body.prompt_cache_options).toEqual({
+          mode: "explicit",
+          ttl: "30m",
+        })
+        expect(body.messages).toEqual([
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: "Stable history",
+                prompt_cache_breakpoint: { mode: "explicit" },
+              },
+            ],
+          },
+        ])
+        return true
+      })
+      .reply(200, {
+        id: "chatcmpl-123",
+        choices: [
+          {
+            message: { role: "assistant", content: "Hello!" },
+            finish_reason: "stop",
+            index: 0,
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      })
+
+    await generateText({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: "Stable history",
+          providerOptions: {
+            openai: {
+              promptCacheBreakpoint: { mode: "explicit" },
+            },
+          },
+        },
+      ],
     })
     scope.done()
   })
@@ -152,11 +250,13 @@ describe("Usage reporting", () => {
         .post(/\/project-prompt\/test-prompt\/production/)
         .reply(200, {
           id: "chatcmpl-123",
-          choices: [{
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop",
-            index: 0,
-          }],
+          choices: [
+            {
+              message: { role: "assistant", content: "Hello!" },
+              finish_reason: "stop",
+              index: 0,
+            },
+          ],
           usage: {
             prompt_tokens: 10,
             completion_tokens: 5,
@@ -178,16 +278,19 @@ describe("Usage reporting", () => {
         .post(/\/project-prompt\/test-prompt\/production/)
         .reply(200, {
           id: "chatcmpl-123",
-          choices: [{
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop",
-            index: 0,
-          }],
+          choices: [
+            {
+              message: { role: "assistant", content: "Hello!" },
+              finish_reason: "stop",
+              index: 0,
+            },
+          ],
           usage: {
             prompt_tokens: 16454,
             completion_tokens: 333,
             prompt_tokens_details: {
               cached_tokens: 13128,
+              cache_write_tokens: 2622,
             },
             completion_tokens_details: {
               reasoning_tokens: 50,
@@ -203,6 +306,7 @@ describe("Usage reporting", () => {
           promptTokens: 16454,
           completionTokens: 333,
           cachedInputTokens: 13128,
+          cacheWriteInputTokens: 2622,
           reasoningTokens: 50,
         },
       })
@@ -226,11 +330,13 @@ describe("Usage reporting", () => {
         .post(/\/project-prompt\/test-prompt\/production/)
         .reply(200, {
           id: "chatcmpl-123",
-          choices: [{
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop",
-            index: 0,
-          }],
+          choices: [
+            {
+              message: { role: "assistant", content: "Hello!" },
+              finish_reason: "stop",
+              index: 0,
+            },
+          ],
           usage: {
             prompt_tokens: 16454,
             completion_tokens: 333,
@@ -244,11 +350,15 @@ describe("Usage reporting", () => {
       const model = createModel()
       const result = await model.doGenerate(defaultCallOptions)
 
-      const langtailMeta = result.providerMetadata?.langtail as Record<string, any>
+      const langtailMeta = result.providerMetadata?.langtail as Record<
+        string,
+        any
+      >
       expect(langtailMeta.usage.rawUsage).toEqual(rawUsage)
       expect(langtailMeta.usage.promptTokens).toBe(16454)
       expect(langtailMeta.usage.completionTokens).toBe(333)
       expect(langtailMeta.usage.cachedInputTokens).toBe(13128)
+      expect(langtailMeta.usage.cacheWriteInputTokens).toBe(0)
       scope.done()
     })
 
@@ -257,11 +367,13 @@ describe("Usage reporting", () => {
         .post(/\/project-prompt\/test-prompt\/production/)
         .reply(200, {
           id: "chatcmpl-123",
-          choices: [{
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop",
-            index: 0,
-          }],
+          choices: [
+            {
+              message: { role: "assistant", content: "Hello!" },
+              finish_reason: "stop",
+              index: 0,
+            },
+          ],
           usage: {
             prompt_tokens: 100,
             completion_tokens: 20,
@@ -289,6 +401,7 @@ describe("Usage reporting", () => {
           promptTokens: 100,
           completionTokens: 20,
           cachedInputTokens: 50,
+          cacheWriteInputTokens: 0,
           reasoningTokens: 10,
         },
       })
@@ -300,11 +413,13 @@ describe("Usage reporting", () => {
         .post(/\/project-prompt\/test-prompt\/production/)
         .reply(200, {
           id: "chatcmpl-123",
-          choices: [{
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop",
-            index: 0,
-          }],
+          choices: [
+            {
+              message: { role: "assistant", content: "Hello!" },
+              finish_reason: "stop",
+              index: 0,
+            },
+          ],
           usage: {
             prompt_tokens: 100,
             completion_tokens: 20,
@@ -314,8 +429,12 @@ describe("Usage reporting", () => {
       const model = createModel()
       const result = await model.doGenerate(defaultCallOptions)
 
-      const langtailMeta = result.providerMetadata?.langtail as Record<string, any>
+      const langtailMeta = result.providerMetadata?.langtail as Record<
+        string,
+        any
+      >
       expect(langtailMeta.usage.cachedInputTokens).toBe(0)
+      expect(langtailMeta.usage.cacheWriteInputTokens).toBe(0)
       expect(langtailMeta.usage.reasoningTokens).toBe(0)
       expect(langtailMeta.usage.rawUsage).toBeUndefined()
       scope.done()
@@ -346,29 +465,37 @@ describe("Usage reporting", () => {
     it("should emit usage in the finish event", async () => {
       const scope = nock(BASE_URL)
         .post(/\/project-prompt\/test-prompt\/production/)
-        .reply(200, createSSEResponse([
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: { role: "assistant", content: "Hi" },
-              index: 0,
-            }],
-          },
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: {},
-              finish_reason: "stop",
-              index: 0,
-            }],
-            usage: {
-              prompt_tokens: 10,
-              completion_tokens: 5,
+        .reply(
+          200,
+          createSSEResponse([
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: { role: "assistant", content: "Hi" },
+                  index: 0,
+                },
+              ],
             },
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: {},
+                  finish_reason: "stop",
+                  index: 0,
+                },
+              ],
+              usage: {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+              },
+            },
+          ]),
+          {
+            "content-type": "text/event-stream",
           },
-        ]), {
-          "content-type": "text/event-stream",
-        })
+        )
 
       const model = createModel()
       const { stream } = await model.doStream(defaultCallOptions)
@@ -396,36 +523,45 @@ describe("Usage reporting", () => {
 
       const scope = nock(BASE_URL)
         .post(/\/project-prompt\/test-prompt\/production/)
-        .reply(200, createSSEResponse([
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: { role: "assistant", content: "Hi" },
-              index: 0,
-            }],
-          },
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: {},
-              finish_reason: "stop",
-              index: 0,
-            }],
-            usage: {
-              prompt_tokens: 16454,
-              completion_tokens: 333,
-              prompt_tokens_details: {
-                cached_tokens: 13128,
-              },
-              completion_tokens_details: {
-                reasoning_tokens: 0,
-              },
-              raw_usage: rawUsage,
+        .reply(
+          200,
+          createSSEResponse([
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: { role: "assistant", content: "Hi" },
+                  index: 0,
+                },
+              ],
             },
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: {},
+                  finish_reason: "stop",
+                  index: 0,
+                },
+              ],
+              usage: {
+                prompt_tokens: 16454,
+                completion_tokens: 333,
+                prompt_tokens_details: {
+                  cached_tokens: 13128,
+                  cache_write_tokens: 2622,
+                },
+                completion_tokens_details: {
+                  reasoning_tokens: 0,
+                },
+                raw_usage: rawUsage,
+              },
+            },
+          ]),
+          {
+            "content-type": "text/event-stream",
           },
-        ]), {
-          "content-type": "text/event-stream",
-        })
+        )
 
       const model = createModel()
       const { stream } = await model.doStream(defaultCallOptions)
@@ -434,11 +570,15 @@ describe("Usage reporting", () => {
       const finishPart = parts.find((p) => p.type === "finish")
       expect(finishPart).toBeDefined()
       if (finishPart?.type === "finish") {
-        const langtailMeta = finishPart.providerMetadata?.langtail as Record<string, any>
+        const langtailMeta = finishPart.providerMetadata?.langtail as Record<
+          string,
+          any
+        >
         expect(langtailMeta.usage).toEqual({
           promptTokens: 16454,
           completionTokens: 333,
           cachedInputTokens: 13128,
+          cacheWriteInputTokens: 2622,
           reasoningTokens: 0,
           rawUsage,
         })
@@ -449,35 +589,43 @@ describe("Usage reporting", () => {
     it("should preserve providerMetadata.openai in stream finish", async () => {
       const scope = nock(BASE_URL)
         .post(/\/project-prompt\/test-prompt\/production/)
-        .reply(200, createSSEResponse([
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: { role: "assistant", content: "Hi" },
-              index: 0,
-            }],
-          },
-          {
-            id: "chatcmpl-123",
-            choices: [{
-              delta: {},
-              finish_reason: "stop",
-              index: 0,
-            }],
-            usage: {
-              prompt_tokens: 100,
-              completion_tokens: 20,
-              prompt_tokens_details: {
-                cached_tokens: 50,
-              },
-              completion_tokens_details: {
-                reasoning_tokens: 10,
+        .reply(
+          200,
+          createSSEResponse([
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: { role: "assistant", content: "Hi" },
+                  index: 0,
+                },
+              ],
+            },
+            {
+              id: "chatcmpl-123",
+              choices: [
+                {
+                  delta: {},
+                  finish_reason: "stop",
+                  index: 0,
+                },
+              ],
+              usage: {
+                prompt_tokens: 100,
+                completion_tokens: 20,
+                prompt_tokens_details: {
+                  cached_tokens: 50,
+                },
+                completion_tokens_details: {
+                  reasoning_tokens: 10,
+                },
               },
             },
+          ]),
+          {
+            "content-type": "text/event-stream",
           },
-        ]), {
-          "content-type": "text/event-stream",
-        })
+        )
 
       const model = createModel()
       const { stream } = await model.doStream(defaultCallOptions)
@@ -494,6 +642,7 @@ describe("Usage reporting", () => {
           promptTokens: 100,
           completionTokens: 20,
           cachedInputTokens: 50,
+          cacheWriteInputTokens: 0,
           reasoningTokens: 10,
         })
       }

--- a/src/vercel-ai/langtail-language-model.ts
+++ b/src/vercel-ai/langtail-language-model.ts
@@ -205,6 +205,8 @@ export class LangtailChatLanguageModel<
       // model specific settings:
       user: this.settings.user,
       parallel_tool_calls: true,
+      prompt_cache_key: this.settings.prompt_cache_key,
+      prompt_cache_options: this.settings.prompt_cache_options,
 
       // standardized settings:
       max_tokens: maxTokens,
@@ -371,6 +373,8 @@ export class LangtailChatLanguageModel<
           completionTokens: response.usage.completion_tokens ?? 0,
           cachedInputTokens:
             response.usage.prompt_tokens_details?.cached_tokens ?? 0,
+          cacheWriteInputTokens:
+            response.usage.prompt_tokens_details?.cache_write_tokens ?? 0,
           reasoningTokens:
             response.usage.completion_tokens_details?.reasoning_tokens ?? 0,
           ...(response.usage.raw_usage
@@ -385,7 +389,8 @@ export class LangtailChatLanguageModel<
       | string
       | { type: "text"; text: string; signature?: string }[]
       | { type: "redacted"; data: string }[]
-      | undefined = (choice.message.reasoning ?? choice.message.reasoning_content) as
+      | undefined = (choice.message.reasoning ??
+      choice.message.reasoning_content) as
       | string
       | { type: "text"; text: string; signature?: string }[]
       | { type: "redacted"; data: string }[]
@@ -487,8 +492,8 @@ export class LangtailChatLanguageModel<
 
     return {
       text: refusalAsText
-        ? (choice.message.refusal ?? undefined)
-        : (choice.message.content ?? undefined),
+        ? choice.message.refusal ?? undefined
+        : choice.message.content ?? undefined,
       reasoning: reasoningContent,
       toolCalls: choice.message.tool_calls?.map((toolCall) => ({
         toolCallType: "function",
@@ -670,6 +675,8 @@ export class LangtailChatLanguageModel<
                   promptTokens: value.usage.prompt_tokens ?? 0,
                   completionTokens: value.usage.completion_tokens ?? 0,
                   cachedInputTokens: promptTokenDetails?.cached_tokens ?? 0,
+                  cacheWriteInputTokens:
+                    promptTokenDetails?.cache_write_tokens ?? 0,
                   reasoningTokens:
                     completionTokenDetails?.reasoning_tokens ?? 0,
                   ...(value.usage.raw_usage
@@ -1062,6 +1069,7 @@ const openaiTokenUsageSchema = z
     prompt_tokens_details: z
       .object({
         cached_tokens: z.number().nullish(),
+        cache_write_tokens: z.number().nullish(),
       })
       .nullish(),
     completion_tokens_details: z

--- a/src/vercel-ai/openai-chat-prompt.ts
+++ b/src/vercel-ai/openai-chat-prompt.ts
@@ -1,5 +1,5 @@
 import { ReasoningDetail } from "../reasoning-details-schema"
-import type { MessageProviderMetadata } from "../schemas"
+import type { MessageProviderMetadata, PromptCacheBreakpoint } from "../schemas"
 
 export type OpenAIChatPrompt = Array<ChatCompletionMessageParam>
 
@@ -11,7 +11,7 @@ export type ChatCompletionMessageParam =
 
 export interface ChatCompletionSystemMessageParam {
   role: "system"
-  content: string
+  content: string | Array<ChatCompletionContentPartText>
 }
 
 export interface ChatCompletionUserMessageParam {
@@ -27,12 +27,15 @@ export interface ChatCompletionContentPartImage {
   type: "image_url"
   image_url: {
     url: string
+    detail?: "auto" | "low" | "high"
   }
+  prompt_cache_breakpoint?: PromptCacheBreakpoint
 }
 
 export interface ChatCompletionContentPartText {
   type: "text"
   text: string
+  prompt_cache_breakpoint?: PromptCacheBreakpoint
 }
 
 export interface ChatCompletionAssistantMessageParam {


### PR DESCRIPTION
## Summary

- add strict schema and public types for OpenAI `prompt_cache_key`, `prompt_cache_options`, and content-block `prompt_cache_breakpoint`
- preserve explicit cache fields through `getOpenAIBody` while stripping internal Responses metadata
- map AI SDK `providerOptions.openai.promptCacheBreakpoint` to the final cacheable system/user content block
- expose `cache_write_tokens` as `providerMetadata.langtail.usage.cacheWriteInputTokens` for generate and stream paths
- prepare the package release as `0.16.19`

## Why

GPT-5.6 multi-step agent loops append a changing assistant/tool suffix on every request. The implicit cache breakpoint therefore moves between steps and prevents reuse of a large stable prefix. This adds the complete explicit prompt caching contract so callers can keep stable breakpoints and observe both cache reads and cache writes.

## Compatibility

- malformed cache modes and TTLs are rejected instead of silently forwarded
- existing Anthropic `cache_enabled` / `cache_ttl` behavior remains independent and unchanged
- no OpenAI SDK upgrade is included; local request types are extended narrowly

## Validation

- `pnpm ts`
- `pnpm vitest run --exclude src/openai.spec.ts` — 127 passed, 8 skipped
- focused explicit-cache tests — 27 passed
- `pnpm build`
- `pnpm publish --dry-run --tag latest --no-git-checks`

`src/openai.spec.ts` requires an `OPENAI_API_KEY` and was not runnable in this workspace.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/langtail/codesmith/langtail-node/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788037317&installation_model_id=18953&pr_number=89&repository=langtail%2Flangtail-node&return_to=https%3A%2F%2Fgithub.com%2Flangtail%2Flangtail-node%2Fpull%2F89&signature=59c9d94c1b082cbb05c60d0fa829d8a9d70f03c231d0aa4849be8c43fa197fdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->