### PR TITLE
Preserve prompt cache breakpoints across tool turns

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,12 @@ jobs:
           TEST_LIVE: true
         run: pnpm test
 
+      - name: build package
+        run: pnpm build
+
+      - name: test CommonJS and ESM package conversions
+        run: pnpm test:package
+
   publish:
     runs-on: ubuntu-latest
     name: Publish to NPM
@@ -96,3 +102,4 @@ jobs:
         name: Publish package
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          tag: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.16.20
+
+- Preserve Vercel AI SDK `providerOptions.openai.promptCacheBreakpoint` on assistant message content and on the final emitted tool-result message/content block, enabling explicit caching across multi-step agent turns.
+
 ## 0.16.19
 
 - Add complete OpenAI explicit prompt caching support, including request-wide `prompt_cache_key` and `prompt_cache_options` fields and content-block `prompt_cache_breakpoint` markers with strict validation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langtail",
-  "version": "0.16.19",
+  "version": "0.16.20",
   "description": "",
   "main": "./Langtail.js",
   "packageManager": "pnpm@8.15.6",
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test": "vitest",
+    "test:package": "node --test test/package/*.package.cjs test/package/*.package.mjs",
     "ts": "tsc --noEmit",
     "format": "prettier --write .",
     "build": "pnpm run clean && tsup && copyfiles -u 1 src/bin/*.template dist/ && node src/buildHelpers/moveFiles.js",

--- a/src/vercel-ai/convert-to-openai-chat-messages.spec.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.spec.ts
@@ -70,6 +70,139 @@ describe("convertToOpenAIChatMessages explicit prompt caching", () => {
     ])
   })
 
+  it("marks assistant content while preserving tool calls", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I will check both sources." },
+          {
+            type: "tool-call",
+            toolCallId: "call-weather",
+            toolName: "weather",
+            args: { city: "Prague" },
+          },
+        ],
+        providerMetadata: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "I will check both sources.",
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+        tool_calls: [
+          {
+            id: "call-weather",
+            type: "function",
+            function: {
+              name: "weather",
+              arguments: '{"city":"Prague"}',
+            },
+          },
+        ],
+      },
+    ])
+  })
+
+  it("marks only the final emitted tool message", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-weather",
+            toolName: "weather",
+            result: { temperature: 25 },
+          },
+          {
+            type: "tool-result",
+            toolCallId: "call-time",
+            toolName: "time",
+            result: { time: "21:15" },
+          },
+        ],
+        providerMetadata: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "tool",
+        tool_call_id: "call-weather",
+        content: '{"temperature":25}',
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-time",
+        content: [
+          {
+            type: "text",
+            text: '{"time":"21:15"}',
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ])
+  })
+
+  it("marks the final block of rich tool content", () => {
+    const prompt: LanguageModelV1Prompt = [
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-map",
+            toolName: "map",
+            result: [
+              { type: "text", text: "Map result" },
+              {
+                type: "image_url",
+                image_url: { url: "https://example.com/map.png" },
+              },
+            ],
+          },
+        ],
+        providerMetadata: {
+          openai: {
+            promptCacheBreakpoint: { mode: "explicit" },
+          },
+        },
+      },
+    ]
+
+    expect(convertToOpenAIChatMessages({ prompt })).toEqual([
+      {
+        role: "tool",
+        tool_call_id: "call-map",
+        content: [
+          { type: "text", text: "Map result" },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/map.png" },
+            prompt_cache_breakpoint: { mode: "explicit" },
+          },
+        ],
+      },
+    ])
+  })
+
   it("leaves unmarked content and Anthropic cache control unchanged", () => {
     const prompt: LanguageModelV1Prompt = [
       {

--- a/src/vercel-ai/convert-to-openai-chat-messages.ts
+++ b/src/vercel-ai/convert-to-openai-chat-messages.ts
@@ -96,6 +96,33 @@ export function convertToOpenAIChatMessages({
 }): OpenAIChatPrompt {
   const messages: OpenAIChatPrompt = []
 
+  const addPromptCacheBreakpoint = (
+    content: string | Array<ChatCompletionContentPart>,
+    promptCacheBreakpoint: PromptCacheBreakpoint | undefined,
+  ): string | Array<ChatCompletionContentPart> => {
+    if (promptCacheBreakpoint === undefined) {
+      return content
+    }
+
+    if (typeof content === "string") {
+      return [
+        {
+          type: "text",
+          text: content,
+          prompt_cache_breakpoint: promptCacheBreakpoint,
+        },
+      ]
+    }
+
+    const convertedContent = content.map((part) => ({ ...part }))
+    const finalContentPart = convertedContent[convertedContent.length - 1]
+    if (finalContentPart !== undefined) {
+      finalContentPart.prompt_cache_breakpoint = promptCacheBreakpoint
+    }
+
+    return convertedContent
+  }
+
   // Helper function to add a message with cacheControl if needed
   const addMessage = (
     message: any,
@@ -305,8 +332,10 @@ export function convertToOpenAIChatMessages({
         addMessage(
           {
             role: "assistant",
-            content:
+            content: addPromptCacheBreakpoint(
               refusalAsText && refusal != null && text === refusal ? "" : text,
+              promptCacheBreakpoint,
+            ),
             refusal,
             reasoning: reasoning.length > 0 ? reasoning : undefined,
             reasoning_details: reasoningDetails,
@@ -320,7 +349,7 @@ export function convertToOpenAIChatMessages({
       }
 
       case "tool": {
-        for (const toolResponse of content) {
+        for (const [toolResponseIndex, toolResponse] of content.entries()) {
           let toolContent: string | Array<ChatCompletionContentPart>
 
           // Check if result is already in message array format
@@ -365,7 +394,12 @@ export function convertToOpenAIChatMessages({
             {
               role: "tool",
               tool_call_id: toolResponse.toolCallId,
-              content: toolContent,
+              content: addPromptCacheBreakpoint(
+                toolContent,
+                toolResponseIndex === content.length - 1
+                  ? promptCacheBreakpoint
+                  : undefined,
+              ),
             },
             cacheEnabled,
             cacheTtl,

--- a/src/vercel-ai/openai-chat-prompt.ts
+++ b/src/vercel-ai/openai-chat-prompt.ts
@@ -40,7 +40,7 @@ export interface ChatCompletionContentPartText {
 
 export interface ChatCompletionAssistantMessageParam {
   role: "assistant"
-  content?: string | null
+  content?: string | Array<ChatCompletionContentPart> | null
   refusal?: string | null
   reasoning_details?: ReasoningDetail[] | null
   provider_metadata?: MessageProviderMetadata

--- a/test/package/vercel-ai-conversion.package.cjs
+++ b/test/package/vercel-ai-conversion.package.cjs
@@ -1,0 +1,128 @@
+const assert = require("node:assert/strict")
+const test = require("node:test")
+const { generateText } = require("ai")
+const nock = require("nock")
+const { createLangtail } = require("../../vercel-ai/index.js")
+
+const BASE_URL = "https://cjs-package-test.langtail.invalid"
+const BREAKPOINT = { mode: "explicit" }
+
+test("CommonJS preserves assistant and tool prompt cache breakpoints", async () => {
+  const model = createLangtail({
+    apiKey: "test-api-key",
+    baseURL: BASE_URL,
+  })("test-prompt")
+
+  const scope = nock(BASE_URL)
+    .post(/\/project-prompt\/test-prompt\/production\/?$/, (body) => {
+      assert.deepEqual(body.messages, [
+        { role: "user", content: "Check Prague" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I will check the weather and time.",
+              prompt_cache_breakpoint: BREAKPOINT,
+            },
+          ],
+          tool_calls: [
+            {
+              id: "call-weather",
+              type: "function",
+              function: {
+                name: "weather",
+                arguments: '{"city":"Prague"}',
+              },
+            },
+            {
+              id: "call-time",
+              type: "function",
+              function: {
+                name: "time",
+                arguments: '{"city":"Prague"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call-weather",
+          content: '{"temperature":25}',
+        },
+        {
+          role: "tool",
+          tool_call_id: "call-time",
+          content: [
+            {
+              type: "text",
+              text: '{"time":"21:15"}',
+              prompt_cache_breakpoint: BREAKPOINT,
+            },
+          ],
+        },
+      ])
+      return true
+    })
+    .reply(200, {
+      id: "chatcmpl-cjs",
+      choices: [
+        {
+          message: { role: "assistant", content: "Done" },
+          finish_reason: "stop",
+          index: 0,
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 1 },
+    })
+
+  try {
+    await generateText({
+      model,
+      messages: [
+        { role: "user", content: "Check Prague" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will check the weather and time." },
+            {
+              type: "tool-call",
+              toolCallId: "call-weather",
+              toolName: "weather",
+              args: { city: "Prague" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-time",
+              toolName: "time",
+              args: { city: "Prague" },
+            },
+          ],
+          providerOptions: { openai: { promptCacheBreakpoint: BREAKPOINT } },
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-weather",
+              toolName: "weather",
+              result: { temperature: 25 },
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call-time",
+              toolName: "time",
+              result: { time: "21:15" },
+            },
+          ],
+          providerOptions: { openai: { promptCacheBreakpoint: BREAKPOINT } },
+        },
+      ],
+    })
+
+    scope.done()
+  } finally {
+    nock.cleanAll()
+  }
+})

--- a/test/package/vercel-ai-conversion.package.mjs
+++ b/test/package/vercel-ai-conversion.package.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { generateText } from "ai"
+import nock from "nock"
+import { createLangtail } from "../../vercel-ai/index.mjs"
+
+const BASE_URL = "https://esm-package-test.langtail.invalid"
+const BREAKPOINT = { mode: "explicit" }
+
+test("ESM preserves assistant and tool prompt cache breakpoints", async () => {
+  const model = createLangtail({
+    apiKey: "test-api-key",
+    baseURL: BASE_URL,
+  })("test-prompt")
+
+  const scope = nock(BASE_URL)
+    .post(/\/project-prompt\/test-prompt\/production\/?$/, (body) => {
+      assert.deepEqual(body.messages, [
+        { role: "user", content: "Check Prague" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I will check the weather and time.",
+              prompt_cache_breakpoint: BREAKPOINT,
+            },
+          ],
+          tool_calls: [
+            {
+              id: "call-weather",
+              type: "function",
+              function: {
+                name: "weather",
+                arguments: '{"city":"Prague"}',
+              },
+            },
+            {
+              id: "call-time",
+              type: "function",
+              function: {
+                name: "time",
+                arguments: '{"city":"Prague"}',
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "call-weather",
+          content: '{"temperature":25}',
+        },
+        {
+          role: "tool",
+          tool_call_id: "call-time",
+          content: [
+            {
+              type: "text",
+              text: '{"time":"21:15"}',
+              prompt_cache_breakpoint: BREAKPOINT,
+            },
+          ],
+        },
+      ])
+      return true
+    })
+    .reply(200, {
+      id: "chatcmpl-esm",
+      choices: [
+        {
+          message: { role: "assistant", content: "Done" },
+          finish_reason: "stop",
+          index: 0,
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 1 },
+    })
+
+  try {
+    await generateText({
+      model,
+      messages: [
+        { role: "user", content: "Check Prague" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will check the weather and time." },
+            {
+              type: "tool-call",
+              toolCallId: "call-weather",
+              toolName: "weather",
+              args: { city: "Prague" },
+            },
+            {
+              type: "tool-call",
+              toolCallId: "call-time",
+              toolName: "time",
+              args: { city: "Prague" },
+            },
+          ],
+          providerOptions: { openai: { promptCacheBreakpoint: BREAKPOINT } },
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-weather",
+              toolName: "weather",
+              result: { temperature: 25 },
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call-time",
+              toolName: "time",
+              result: { time: "21:15" },
+            },
+          ],
+          providerOptions: { openai: { promptCacheBreakpoint: BREAKPOINT } },
+        },
+      ],
+    })
+
+    scope.done()
+  } finally {
+    nock.cleanAll()
+  }
+})


### PR DESCRIPTION
## What changed

- preserve `providerOptions.openai.promptCacheBreakpoint` on assistant content
- apply tool breakpoints only to the final emitted tool message and its final content block
- add source regressions plus built-package CommonJS and ESM end-to-end conversion tests
- bump Langtail to 0.16.20 and make the release workflow publish the explicit `latest` dist-tag

## Why

Langtail 0.16.19 preserved explicit cache breakpoints for system and user messages but dropped them at assistant and tool-result boundaries. That prevented GPT-5.6 explicit caching from surviving multi-step Vercel AI agent turns.

## Validation

- `pnpm ts`
- focused converter and request tests: 18 passed
- offline suite: 130 passed, 8 live tests skipped
- `pnpm build`
- `pnpm test:package`: CommonJS and ESM passed
- Prettier check
- `npm pack --dry-run --json`

The one pre-existing live OpenAI proxy test requires the repository API key and will run in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/langtail/codesmith/langtail-node/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117389&installation_model_id=18953&pr_number=90&repository=langtail%2Flangtail-node&return_to=https%3A%2F%2Fgithub.com%2Flangtail%2Flangtail-node%2Fpull%2F90&signature=e458159a8144621f1e84529e4022085e548ad2848a5d18d78a815704a2f5a893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->