### PR TITLE
Support Meta's meta-responses-v1 reasoning format

### DIFF
--- a/src/reasoning-details-schema.ts
+++ b/src/reasoning-details-schema.ts
@@ -6,6 +6,7 @@ export const ReasoningFormat = {
   XAIResponsesV1: "xai-responses-v1",
   AnthropicClaudeV1: "anthropic-claude-v1",
   GoogleGeminiV1: "google-gemini-v1",
+  MetaResponsesV1: "meta-responses-v1",
 } as const
 
 export type ReasoningFormat =
@@ -33,6 +34,7 @@ export const CommonReasoningDetailSchema = z.object({
       ReasoningFormat.XAIResponsesV1,
       ReasoningFormat.AnthropicClaudeV1,
       ReasoningFormat.GoogleGeminiV1,
+      ReasoningFormat.MetaResponsesV1,
     ])
     .nullish(),
   index: z.number().optional(),

--- a/src/reasoning-details.spec.ts
+++ b/src/reasoning-details.spec.ts
@@ -109,6 +109,20 @@ describe("ReasoningDetail Schemas", () => {
       const result = ReasoningDetailUnionSchema.parse(detail)
       expect(result.type).toBe(ReasoningDetailType.Encrypted)
     })
+
+    it("should parse encrypted type in Meta's format", () => {
+      const detail = {
+        type: ReasoningDetailType.Encrypted,
+        data: "encrypted_data",
+        id: "rs_1",
+        // Raw literal on purpose: this is what arrives over the wire, so the
+        // test still exercises the enum if the constant is missing.
+        format: "meta-responses-v1",
+      }
+
+      const result = ReasoningDetailUnionSchema.parse(detail)
+      expect(result.format).toBe("meta-responses-v1")
+    })
   })
 
   describe("ReasoningDetailArraySchema", () => {
@@ -155,6 +169,21 @@ describe("ReasoningDetail Schemas", () => {
       expect(result).toHaveLength(2)
       expect(result[0].type).toBe(ReasoningDetailType.Text)
       expect(result[1].type).toBe(ReasoningDetailType.Summary)
+    })
+
+    it("should keep Meta reasoning details instead of filtering them out", () => {
+      const details = [
+        {
+          type: ReasoningDetailType.Encrypted,
+          data: "encrypted_data",
+          id: "rs_1",
+          format: "meta-responses-v1",
+        },
+      ]
+
+      const result = ReasoningDetailArraySchema.parse(details)
+      expect(result).toHaveLength(1)
+      expect(result[0].format).toBe("meta-responses-v1")
     })
 
     it("should handle empty array", () => {


### PR DESCRIPTION
## Problem

Muse Spark 1.2 (Meta, via OpenRouter) returns `reasoning_details` with `type: "reasoning.encrypted"` and `format: "meta-responses-v1"`. That format is missing from `ReasoningFormat`.

Unlike the main app — where the same gap threw a `ZodError` and broke the logs view — the SDK **fails soft**. `ReasoningDetailArraySchema` drops anything it can't parse:

```ts
const ReasoningDetailsWithUnknownSchema = z.union([
  ReasoningDetailUnionSchema,
  z.unknown().transform(() => null),
])
```

So Meta reasoning details were silently discarded instead of erroring, which loses reasoning continuity across turns. No crash, no warning — just missing data.

## Changes

- Add `MetaResponsesV1: "meta-responses-v1"` to `ReasoningFormat` and to `CommonReasoningDetailSchema`'s enum
- Two tests: one at the union level, one at the array level (the array one is what actually demonstrates the silent drop)

Both tests use the raw `"meta-responses-v1"` string rather than the new constant. Using the constant made them pass `format: undefined` when the constant was absent, so they failed for the wrong reason and would not have caught a regression.

## Testing

Without the schema change, both new tests fail for the right reasons:

- union: `invalid_enum_value ... received 'meta-responses-v1'`
- array: `expected [] to have a length of 1 but got +0` — the silent drop

With it:

- `pnpm exec vitest run src/reasoning-details.spec.ts` — 21/21 pass
- Full suite — 132 passed, 12/13 files. `openai.spec.ts` fails only because `OPENAI_API_KEY` isn't set locally
- `pnpm run ts` — clean

## Related

langtail/langtail#1039 adds the same format to the app. That PR carries a cast at the `getOpenAIBody` boundary because the published SDK type still has the old five formats; the cast can be dropped once this ships and the dependency is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/langtail/codesmith/langtail-node/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788689202&installation_model_id=18953&pr_number=91&repository=langtail%2Flangtail-node&return_to=https%3A%2F%2Fgithub.com%2Flangtail%2Flangtail-node%2Fpull%2F91&signature=087080cadd1f0563ea4acd7e6045d7f209a9bc564349e419b2ddc28d80ea646b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->